### PR TITLE
Add support for ignore rendering files listed in cookiecutter.json

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -8,6 +8,7 @@ cookiecutter.generate
 Functions for generating a project from a project template.
 """
 from __future__ import unicode_literals
+import fnmatch
 import logging
 import os
 import shutil
@@ -30,6 +31,17 @@ if sys.version_info[:2] < (2, 7):
 else:
     import json
     from collections import OrderedDict
+
+
+def ignore_file(infile, context):
+    try:
+        for ignore in context["cookiecutter"]["_ignore_files"]:
+            if fnmatch.fnmatch(infile, ignore):
+                return True
+    except KeyError:
+        return False
+
+    return False
 
 
 def generate_context(context_file='cookiecutter.json', default_context=None):
@@ -67,11 +79,11 @@ def generate_file(project_dir, infile, context, env):
     2. Deal with infile appropriately:
 
         a. If infile is a binary file, copy it over without rendering.
-        b. If infile is a text file, render its contents and write the 
+        b. If infile is a text file, render its contents and write the
            rendered infile to outfile.
 
     .. precondition::
-    
+
         When calling `generate_file()`, the root template dir must be the
         current working directory. Using `utils.work_in()` is the recommended
         way to perform this directory change.
@@ -90,9 +102,14 @@ def generate_file(project_dir, infile, context, env):
     outfile = os.path.join(project_dir, outfile_tmpl.render(**context))
     logging.debug("outfile is {0}".format(outfile))
 
+    # Just copy over ignored files. Don't render.
+    if ignore_file(infile, context):
+        logging.debug("Copying ignored file {0} to {1} without rendering"
+                      .format(infile, outfile))
+        shutil.copyfile(infile, outfile)
+
     # Just copy over binary files. Don't render.
-    logging.debug("Check {0} to see if it's a binary".format(infile))
-    if is_binary(infile):
+    elif is_binary(infile):
         logging.debug("Copying binary {0} to {1} without rendering"
                       .format(infile, outfile))
         shutil.copyfile(infile, outfile)

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -34,6 +34,10 @@ else:
 
 
 def ignore_file(infile, context):
+    """ignore_file(infile, context) -> bool
+    
+    Returns True if `infile` filename match some pattern on `_ignore_files` context setting.
+    """
     try:
         for ignore in context["cookiecutter"]["_ignore_files"]:
             if fnmatch.fnmatch(infile, ignore):

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -27,6 +27,10 @@ def prompt_for_config(context):
     cookiecutter_dict = {}
 
     for key, val in iteritems(context['cookiecutter']):
+        if key.startswith("_"):
+            cookiecutter_dict[key] = val
+            continue
+
         prompt = "{0} (default is \"{1}\")? ".format(key, val)
 
         if PY3:

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -27,6 +27,16 @@ Or this::
 
 See http://jinja.pocoo.org/docs/templates/#escaping for more info.
 
+You can also put the template file extensions in `_ignore_files` key in
+your `cookiecutter.json` file::
+
+    {
+        "repo_name": "sample",
+        "_ignore_files": [
+            "*.html"
+        ]
+    }
+
 Other common issues
 -------------------
 

--- a/tests/test-generate-ignore/{{cookiecutter.repo_name}}/README.rst
+++ b/tests/test-generate-ignore/{{cookiecutter.repo_name}}/README.rst
@@ -1,0 +1,5 @@
+============
+Fake Project
+============
+
+{{cookiecutter.do_not_ignore}}

--- a/tests/test-generate-ignore/{{cookiecutter.repo_name}}/README.txt
+++ b/tests/test-generate-ignore/{{cookiecutter.repo_name}}/README.txt
@@ -1,0 +1,5 @@
+============
+Fake Project
+============
+
+{{cookiecutter.do_not_ignore}}

--- a/tests/test-generate-ignore/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-sub/README.rst
+++ b/tests/test-generate-ignore/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-sub/README.rst
@@ -1,0 +1,5 @@
+============
+Fake Project
+============
+
+{{cookiecutter.do_not_ignore}}

--- a/tests/test-generate-ignore/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-sub/README.txt
+++ b/tests/test-generate-ignore/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-sub/README.txt
@@ -1,0 +1,5 @@
+============
+Fake Project
+============
+
+{{cookiecutter.do_not_ignore}}

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -188,6 +188,32 @@ class TestGenerateFiles(CookiecutterCleanSystemTestCase):
             os.stat('inputpermissions/script.sh').st_mode & 0o777
         )
 
+    def test_generate_ignore_file_extensions(self):
+        generate.generate_files(
+            context={
+                'cookiecutter': {
+                    "repo_name": "test_ignore",
+                    "do_not_ignore": "Do not ignore!",
+                    "_ignore_files": ["*.txt"]}
+            },
+            repo_dir='tests/test-generate-ignore'
+        )
+
+        with open("test_ignore/README.txt") as f:
+            self.assertIn("{{cookiecutter.do_not_ignore}}", f.read())
+
+        with open("test_ignore/README.rst") as f:
+            self.assertIn("Do not ignore!", f.read())
+
+        with open("test_ignore/test_ignore-sub/README.txt") as f:
+            self.assertIn("{{cookiecutter.do_not_ignore}}", f.read())
+
+        with open("test_ignore/test_ignore-sub/README.rst") as f:
+            self.assertIn("Do not ignore!", f.read())
+
+        if os.path.exists('test_ignore'):
+            shutil.rmtree('test_ignore')
+
 
 class TestGenerateContext(CookiecutterCleanSystemTestCase):
 


### PR DESCRIPTION
You can add a key `_ignore_files` in your cookiecutter.json containing
a list of filenames (or a globs) that will be skipped on rendering.