### PR TITLE
explicitely name unfound hooks in debug logging

### DIFF
--- a/cookiecutter/hooks.py
+++ b/cookiecutter/hooks.py
@@ -67,6 +67,6 @@ def run_hook(hook_name, project_dir):
     '''
     script = find_hooks().get(hook_name)
     if script is None:
-        logging.debug("No hooks found")
+        logging.debug("No {0} hook found".format(hook_name))
         return
     return _run_hook(script, project_dir)


### PR DESCRIPTION
Hi.

Just thought it'd be nice to have a slightly more explicit log message when a hook script is not found.
This is pretty minor, but I don't know, it's bugged me for some reason and for once I could actually find some time to do a little something =). 
