### PR TITLE
Fixed --no-input inconsistency when the repo exists

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -44,6 +44,7 @@ def cookiecutter(input_dir, checkout=None, no_input=False):
         repo_dir = clone(
             repo_url=input_dir,
             checkout=checkout,
+            no_input=no_input,
             clone_to_dir=config_dict['cookiecutters_dir']
         )
     else:
@@ -111,7 +112,7 @@ def main():
             format='%(levelname)s: %(message)s',
             level=logging.INFO
         )
-    
+
     cookiecutter(args.input_dir, args.checkout, args.no_input)
 
 

--- a/cookiecutter/vcs.py
+++ b/cookiecutter/vcs.py
@@ -43,7 +43,7 @@ def identify_repo(repo_url):
     :param repo_url: Repo URL of unknown type.
     :returns: "git", "hg", or None.
     """
-    
+
     if "git" in repo_url:
         return "git"
     elif "bitbucket" in repo_url:
@@ -52,7 +52,7 @@ def identify_repo(repo_url):
         raise UnknownRepoType
 
 
-def clone(repo_url, checkout=None, clone_to_dir="."):
+def clone(repo_url, checkout=None, no_input=None, clone_to_dir="."):
     """
     Clone a repo to the current directory.
 
@@ -63,9 +63,9 @@ def clone(repo_url, checkout=None, clone_to_dir="."):
     # Ensure that clone_to_dir exists
     clone_to_dir = os.path.expanduser(clone_to_dir)
     make_sure_path_exists(clone_to_dir)
-    
+
     repo_type = identify_repo(repo_url)
-    
+
     tail = os.path.split(repo_url)[1]
     if repo_type == "git":
         repo_dir = os.path.normpath(os.path.join(clone_to_dir, tail.rsplit('.git')[0]))
@@ -74,7 +74,11 @@ def clone(repo_url, checkout=None, clone_to_dir="."):
     logging.debug('repo_dir is {0}'.format(repo_dir))
 
     if os.path.isdir(repo_dir):
-        prompt_and_delete_repo(repo_dir)
+        # If no input is enable don't clone and take local
+        if no_input:
+            return repo_dir
+        else:
+            prompt_and_delete_repo(repo_dir)
 
     if repo_type in ["git", "hg"]:
         subprocess.check_call([repo_type, 'clone', repo_url], cwd=clone_to_dir)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -119,8 +119,8 @@ class TestCookiecutterRepoArg(CookiecutterCleanSystemTestCase):
             # HACK: There are only 9 prompts in cookiecutter-pypackage's
             # cookiecutter.json (http://git.io/b-1MVA) but 10 \n chars here.
             # There was an "EOFError: EOF when reading a line" test fail here
-            # out of the blue, which an extra \n fixed. 
-            # Not sure why. There shouldn't be an extra prompt to delete 
+            # out of the blue, which an extra \n fixed.
+            # Not sure why. There shouldn't be an extra prompt to delete
             # the repo, since CookiecutterCleanSystemTestCase ensured that it
             # wasn't present.
             # It's possibly an edge case in CookiecutterCleanSystemTestCase.
@@ -146,6 +146,26 @@ class TestCookiecutterRepoArg(CookiecutterCleanSystemTestCase):
         self.assertTrue(os.path.isfile('module_name/README'))
         self.assertTrue(os.path.exists('module_name/setup.py'))
 
+class TestCookiecutterRepoNoInput(CookiecutterCleanSystemTestCase):
+
+    def test_cookiecutter(self):
+        main.cookiecutter('https://github.com/audreyr/cookiecutter-pypackage.git', no_input=True)
+        clone_dir = os.path.join(os.path.expanduser('~/.cookiecutters'), 'cookiecutter-pypackage')
+        self.assertTrue(os.path.exists(clone_dir))
+
+        if os.path.isdir('boilerplate'):
+            shutil.rmtree('boilerplate')
+
+        main.cookiecutter('https://github.com/audreyr/cookiecutter-pypackage.git', no_input=True)
+
+        self.assertTrue(os.path.exists(clone_dir))
+        self.assertTrue(os.path.isdir('boilerplate'))
+        self.assertTrue(os.path.isfile('boilerplate/README.rst'))
+        self.assertTrue(os.path.exists('boilerplate/setup.py'))
+
+    def tearDown(self):
+        if os.path.isdir('boilerplate'):
+            shutil.rmtree('boilerplate')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When you try to use cookie cutter from a repo that has been already cloned with the no-input flag. An input is shown. 

I fixed it and made a test for the issue. 