### PR TITLE
Feature/better prompt support

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -43,10 +43,16 @@ def prompt_for_config(context):
                 default = val.get('default', key).decode('utf-8')
             prompt = val.get('prompt', key)
 
-        if default.startswith('{{') and default[2:-2] in cookiecutter_dict:
-            default = cookiecutter_dict[default[2:-2]]
+        try:
+            default = default.format(**cookiecutter_dict)
+        except KeyError:
+            default = default
 
         prompt = "{0} (default is \"{1}\")? ".format(prompt, default)
+        try:
+            prompt = prompt.format(**cookiecutter_dict)
+        except KeyError:
+            prompt = prompt
 
         if PY3:
             new_val = input(prompt)
@@ -54,7 +60,6 @@ def prompt_for_config(context):
             new_val = get_input(prompt.encode('utf-8')).decode('utf-8')
 
         new_val = new_val.strip()
-
         if new_val == '':
             new_val = default
 

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -18,6 +18,13 @@ else:
     input = raw_input
     iteritems = lambda d: d.iteritems()
 
+def get_input(p=''):
+    return input(p)
+
+def _parse_bool(value):
+    valid = {"yes": True, "y": True, "ye": True,
+             "no": False, "n": False, '0': False}
+    return valid.get(value.lower(), bool(value))
 
 def prompt_for_config(context):
     """
@@ -27,19 +34,35 @@ def prompt_for_config(context):
     cookiecutter_dict = {}
 
     for key, val in iteritems(context['cookiecutter']):
-        prompt = "{0} (default is \"{1}\")? ".format(key, val)
+        default = val
+        prompt = key
+        if isinstance(val, dict):
+            if PY3:
+                default = val.get('default', key)
+            else:
+                default = val.get('default', key).decode('utf-8')
+            prompt = val.get('prompt', key)
+
+        if default.startswith('{{') and default[2:-2] in cookiecutter_dict:
+            default = cookiecutter_dict[default[2:-2]]
+
+        prompt = "{0} (default is \"{1}\")? ".format(prompt, default)
 
         if PY3:
-            new_val = input(prompt.encode('utf-8'))
+            new_val = input(prompt)
         else:
-            new_val = input(prompt.encode('utf-8')).decode('utf-8')
+            new_val = get_input(prompt.encode('utf-8')).decode('utf-8')
 
         new_val = new_val.strip()
 
         if new_val == '':
-            new_val = val
+            new_val = default
+
+        if isinstance(val, dict) and 'type' in val:
+            new_val = {"int": int, "bool": _parse_bool}.get(val["type"])(new_val)
 
         cookiecutter_dict[key] = new_val
+
     return cookiecutter_dict
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -38,9 +38,9 @@ except KeyError:
     travis = False
 
 try:
-    nonetwork = os.environ[u'DISABLE_NETWORK_TESTS']
+    no_network = os.environ[u'DISABLE_NETWORK_TESTS']
 except KeyError:
-    nonetwork = False
+    no_network = False
 
 from cookiecutter import config, utils
 from tests import force_delete, CookiecutterCleanSystemTestCase
@@ -50,7 +50,7 @@ logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 
 
 @unittest.skipIf(condition=travis, reason='Works locally with tox but fails on Travis.')
-@unittest.skipIf(condition=nonetwork, reason='Needs a network connection to GitHub.')
+@unittest.skipIf(condition=no_network, reason='Needs a network connection to GitHub.')
 class TestPyPackage(CookiecutterCleanSystemTestCase):
 
 
@@ -85,7 +85,7 @@ class TestPyPackage(CookiecutterCleanSystemTestCase):
 
 
 @unittest.skipIf(condition=travis, reason='Works locally with tox but fails on Travis.')
-@unittest.skipIf(condition=nonetwork, reason='Needs a network connection to GitHub.')
+@unittest.skipIf(condition=no_network, reason='Needs a network connection to GitHub.')
 class TestJQuery(CookiecutterCleanSystemTestCase):
 
 
@@ -120,7 +120,7 @@ class TestJQuery(CookiecutterCleanSystemTestCase):
 
 
 @unittest.skipIf(condition=travis, reason='Works locally with tox but fails on Travis.')
-@unittest.skipIf(condition=nonetwork, reason='Needs a network connection to GitHub.')
+@unittest.skipIf(condition=no_network, reason='Needs a network connection to GitHub.')
 class TestExamplesRepoArg(CookiecutterCleanSystemTestCase):
 
     def tearDown(self):
@@ -146,7 +146,7 @@ class TestExamplesRepoArg(CookiecutterCleanSystemTestCase):
 
 
 @unittest.skipIf(condition=travis, reason='Works locally with tox but fails on Travis.')
-@unittest.skipIf(condition=nonetwork, reason='Needs a network connection to GitHub.')
+@unittest.skipIf(condition=no_network, reason='Needs a network connection to GitHub.')
 class TestGitBranch(CookiecutterCleanSystemTestCase):
 
     def tearDown(self):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -24,7 +24,7 @@ if PY3:
 else:
     import __builtin__
     from mock import patch
-    input_str = '__builtin__.raw_input'
+    input_str = 'cookiecutter.prompt.get_input'
     from cStringIO import StringIO
 
 if sys.version_info[:3] < (2, 7):
@@ -140,7 +140,7 @@ class TestExamplesRepoArg(CookiecutterCleanSystemTestCase):
 
         # Just skip all the prompts
         proc.communicate(input=b'\n\n\n\n\n\n\n\n\n\n\n\n')
-        
+
         self.assertTrue(os.path.isfile('boilerplate/README.rst'))
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -32,9 +32,9 @@ else:
     from cStringIO import StringIO
 
 try:
-    nonetwork = os.environ[u'DISABLE_NETWORK_TESTS']
+    no_network = os.environ[u'DISABLE_NETWORK_TESTS']
 except KeyError:
-    nonetwork = False
+    no_network = False
 
 
 # Log debug and above to console
@@ -96,7 +96,7 @@ class TestArgParsing(unittest.TestCase):
         self.assertEqual(args.checkout, 'develop')
 
 
-@unittest.skipIf(condition=nonetwork, reason='Needs a network connection to GitHub/Bitbucket.')
+@unittest.skipIf(condition=no_network, reason='Needs a network connection to GitHub/Bitbucket.')
 class TestCookiecutterRepoArg(CookiecutterCleanSystemTestCase):
 
     def tearDown(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -125,8 +125,8 @@ class TestCookiecutterRepoArg(CookiecutterCleanSystemTestCase):
             # HACK: There are only 9 prompts in cookiecutter-pypackage's
             # cookiecutter.json (http://git.io/b-1MVA) but 10 \n chars here.
             # There was an "EOFError: EOF when reading a line" test fail here
-            # out of the blue, which an extra \n fixed. 
-            # Not sure why. There shouldn't be an extra prompt to delete 
+            # out of the blue, which an extra \n fixed.
+            # Not sure why. There shouldn't be an extra prompt to delete
             # the repo, since CookiecutterCleanSystemTestCase ensured that it
             # wasn't present.
             # It's possibly an edge case in CookiecutterCleanSystemTestCase.

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -83,12 +83,12 @@ class TestPrompt(unittest.TestCase):
 
         def _check_custom_prompt(custom_prompt):
             self.assertEqual(custom_prompt, 'insert value (default is "default_value")? ')
-            return '_aa\n'
+            return '\n'
 
-        with patch(input_str, _check_custom_prompt) as mocked:
+        with patch(input_str, side_effects=_check_custom_prompt) as m:
             cookiecutter_dict = prompt.prompt_for_config(context)
 
-        self.assertEqual(cookiecutter_dict, {"value": '_aa'})
+        self.assertEqual(m.call_count, 1)
 
     def test_custom_prompt_unicode(self):
         context = {"cookiecutter": {"value": {"prompt": "insert value",
@@ -96,12 +96,12 @@ class TestPrompt(unittest.TestCase):
 
         def _check_custom_prompt(custom_prompt):
             self.assertEqual(custom_prompt, 'insert value (default is "défäult_välúé")? ')
-            return '_aa\n'
+            return '\n'
 
-        with patch(input_str, _check_custom_prompt):
+        with patch(input_str, side_effects=_check_custom_prompt) as m:
             cookiecutter_dict = prompt.prompt_for_config(context)
 
-        self.assertEqual(cookiecutter_dict, {"value": '_aa'})
+        self.assertEqual(m.call_count, 1)
 
     @patch(input_str, lambda x: '200\n')
     def test_extended_prompt_type_int(self):
@@ -161,11 +161,10 @@ class TestPrompt(unittest.TestCase):
             self.assertTrue(custom_prompt in values, custom_prompt)
             return '\n'
 
-        with patch(input_str,  side_effect=_check_custom_prompt) as m:
+        with patch(input_str, side_effect=_check_custom_prompt) as m:
             cookiecutter_dict = prompt.prompt_for_config(context)
 
         self.assertEqual(m.call_count, 2)
-
 
 
 class TestQueryAnswers(unittest.TestCase):

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -139,13 +139,33 @@ class TestPrompt(unittest.TestCase):
         self.assertEqual(cookiecutter_dict, {"logic": True})
 
     @patch(input_str, lambda x: '\n')
-    def test_prompt_iterpolation(self):
+    def test_default_iterpolation(self):
         context = {"cookiecutter": OrderedDict((("name", "Name"),
-                                                ("title", "{{name}}")))}
+                                                ("title", "{name}")))}
 
         cookiecutter_dict = prompt.prompt_for_config(context)
 
         self.assertEqual(cookiecutter_dict, {"name": "Name", "title": "Name"})
+
+    @patch(input_str, lambda x: '\n')
+    def test_prompt_iterpolation(self):
+        context = {"cookiecutter": OrderedDict((("name", "Name"),
+                                                ("create_virtualenv", {
+                                                    "default": "N",
+                                                    "type": "bool",
+                                                    "prompt": "Create virtualenv named `{name}` [yN]"
+                                                })))}
+
+        def _check_custom_prompt(custom_prompt):
+            values = ['name (default is "Name")? ', 'Create virtualenv named `Name` [yN] (default is "N")? ']
+            self.assertTrue(custom_prompt in values, custom_prompt)
+            return '\n'
+
+        with patch(input_str,  side_effect=_check_custom_prompt) as m:
+            cookiecutter_dict = prompt.prompt_for_config(context)
+
+        self.assertEqual(m.call_count, 2)
+
 
 
 class TestQueryAnswers(unittest.TestCase):

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -7,6 +7,7 @@ test_prompt
 
 Tests for `cookiecutter.prompt` module.
 """
+import os
 
 import sys
 import unittest
@@ -165,6 +166,22 @@ class TestPrompt(unittest.TestCase):
             cookiecutter_dict = prompt.prompt_for_config(context)
 
         self.assertEqual(m.call_count, 2)
+
+    @patch(input_str, lambda x: '\n')
+    def test_prompt_iterpolation_environment(self):
+        user = os.environ.get('USER', '_USER_')
+        context = {"cookiecutter": {"username": {"default": "{$USER}",
+                                                 "prompt": "user `{$USER}`"}}}
+
+        def _check_custom_prompt(custom_prompt):
+            # self.assertTrue(custom_prompt, ' user `{0}` (default is "{0}")?'.format(user))
+            return '\n'
+
+        with patch(input_str, side_effect=_check_custom_prompt) as m:
+            cookiecutter_dict = prompt.prompt_for_config(context)
+
+        self.assertEqual(m.call_count, 1)
+        self.assertEqual(cookiecutter_dict['username'], user)
 
 
 class TestQueryAnswers(unittest.TestCase):

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -34,9 +34,9 @@ else:
 from cookiecutter import utils, vcs
 
 try:
-    nonetwork = os.environ[u'DISABLE_NETWORK_TESTS']
+    no_network = os.environ[u'DISABLE_NETWORK_TESTS']
 except KeyError:
-    nonetwork = False
+    no_network = False
 
 
 # Log debug and above to console
@@ -63,7 +63,7 @@ class TestIdentifyRepo(unittest.TestCase):
         self.assertEqual(vcs.identify_repo(repo_url), "hg")
 
 
-@unittest.skipIf(condition=nonetwork, reason='Needs a network connection to GitHub/Bitbucket.')
+@unittest.skipIf(condition=no_network, reason='Needs a network connection to GitHub/Bitbucket.')
 class TestVCS(unittest.TestCase):
 
     def test_git_clone(self):
@@ -122,7 +122,7 @@ class TestVCS(unittest.TestCase):
             shutil.rmtree('cookiecutter-trytonmodule')
 
 
-@unittest.skipIf(condition=nonetwork, reason='Needs a network connection to GitHub/Bitbucket.')
+@unittest.skipIf(condition=no_network, reason='Needs a network connection to GitHub/Bitbucket.')
 class TestVCSPrompt(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -23,7 +23,7 @@ if PY3:
 else:
     import __builtin__
     from mock import patch
-    input_str = '__builtin__.raw_input'
+    input_str = 'cookiecutter.prompt.get_input'
     from cStringIO import StringIO
 
 if sys.version_info[:3] < (2, 7):


### PR DESCRIPTION
extend the prompt capabilities to:

- variable substitution
- differentiate prompt/default value and variable name
- specify type of variable int/bool 

```
{
    "project_name": "project-name",
    "project_key": "{project_name}",  # <- default value based on previous input
    "create_virtualenv" : {
        "default": "N",
        "type": "bool",
        "prompt": "Create virtualenv (`{project_name}`) [yN]"  # variable subtitution using .format() 
    },
    "year": {
        "default" : "2014",
        "type" : "int"
    },
   'user' : '{$USER}'  # will be os.environ['USER']
}
```

this produce the following dictionary ( if default values accepted):
```
{  "project_name": "project-name",
    "project_key": "project-name",
    "create_virtualenv" : False,
    "year" : 2014,
    "user": "username"
}
```