### PR TITLE
Gracefully handle config shutdown

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -29,10 +29,14 @@ def prompt_for_config(context):
     for key, val in iteritems(context['cookiecutter']):
         prompt = "{0} (default is \"{1}\")? ".format(key, val)
 
-        if PY3:
-            new_val = input(prompt)
-        else:
-            new_val = input(prompt.encode('utf-8')).decode('utf-8')
+        try:
+            if PY3:
+                new_val = input(prompt)
+            else:
+                new_val = input(prompt.encode('utf-8')).decode('utf-8')
+        except KeyboardInterrupt:
+            # exit and print a new line for emphasis (no traceback)
+            sys.exit("\n")
 
         new_val = new_val.strip()
 

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -23,6 +23,8 @@ def prompt_for_config(context):
     """
     Prompts the user to enter new config, using context as a source for the
     field names and sample values.
+
+    Abortable from command line via "ctrl-c".
     """
     cookiecutter_dict = {}
 


### PR DESCRIPTION
If the user issues "ctrl-C" during a config prompt, `cookiecutter` will suppress the traceback from the `KeyboardInterrupt` exception.

Also adds a test case for when `KeyboardInterrupt` is raised and `SystemExit` is thrown in return.
