### PR TITLE
Get the config file location from $COOKIECUTTER_CONFIG, if set

### DIFF
--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -54,7 +54,8 @@ def get_user_config():
     """
 
     # TODO: test on windows...
-    USER_CONFIG_PATH = os.path.expanduser('~/.cookiecutterrc')
+    USER_CONFIG_PATH = os.environ.get("COOKIECUTTER_CONFIG",
+        os.path.expanduser('~/.cookiecutterrc'))
 
     if os.path.exists(USER_CONFIG_PATH):
         return get_config(USER_CONFIG_PATH)

--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -33,13 +33,13 @@ def get_config(config_path):
     if not os.path.exists(config_path):
         raise ConfigDoesNotExistException
 
-    print("config_path is {0}".format(config_path))
-    with io.open(config_path, encoding="utf-8") as file_handle:
+    print('config_path is {0}'.format(config_path))
+    with io.open(config_path, encoding='utf-8') as file_handle:
         try:
             yaml_dict = yaml.safe_load(file_handle)
         except yaml.scanner.ScannerError:
             raise InvalidConfiguration(
-                "%s is no a valid YAML file" % config_path)
+                '%s is no a valid YAML file' % config_path)
 
     config_dict = copy.copy(DEFAULT_CONFIG)
     config_dict.update(yaml_dict)
@@ -54,7 +54,7 @@ def get_user_config():
     """
 
     # TODO: test on windows...
-    USER_CONFIG_PATH = os.environ.get("COOKIECUTTER_CONFIG",
+    USER_CONFIG_PATH = os.environ.get('COOKIECUTTER_CONFIG',
         os.path.expanduser('~/.cookiecutterrc'))
 
     if os.path.exists(USER_CONFIG_PATH):

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -57,8 +57,10 @@ Possible settings are:
   use Cookiecutter with a repo argument.
 
 If you want to locate the config file somewhere else, you can set the
-environment variable `COOKIECUTTER_CONFIG` to the name of the file you want
-to use.
+environment variable `COOKIECUTTER_CONFIG` to the path to the file you want
+to use. For example::
+
+    export COOKIECUTTER_CONFIG=/home/audreyr/my-custom-config.yaml
 
 Calling Cookiecutter Functions From Python
 ------------------------------------------

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -56,6 +56,10 @@ Possible settings are:
 * cookiecutters_dir: Directory where your cookiecutters are cloned to when you
   use Cookiecutter with a repo argument.
 
+If you want to locate the config file somewhere else, you can set the
+environment variable `COOKIECUTTER_CONFIG` to the name of the file you want
+to use.
+
 Calling Cookiecutter Functions From Python
 ------------------------------------------
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,12 +30,12 @@ class TestGetConfig(unittest.TestCase):
         """ Opening and reading config file """
         conf = config.get_config('tests/test-config/valid-config.yaml')
         expected_conf = {
-        	'cookiecutters_dir': '/home/example/some-path-to-templates',
-        	'default_context': {
-        		"full_name": "Firstname Lastname",
-        		"email": "firstname.lastname@gmail.com",
-        		"github_username": "example"
-        	}
+                'cookiecutters_dir': '/home/example/some-path-to-templates',
+                'default_context': {
+                        'full_name': 'Firstname Lastname',
+                        'email': 'firstname.lastname@gmail.com',
+                        'github_username': 'example'
+                }
         }
         self.assertEqual(conf, expected_conf)
 
@@ -55,7 +55,7 @@ class TestGetConfig(unittest.TestCase):
         An invalid config file should raise an `InvalidConfiguration` exception.
         """
         self.assertRaises(InvalidConfiguration, config.get_config,
-                          "tests/test-config/invalid-config.yaml")
+                          'tests/test-config/invalid-config.yaml')
 
 
 class TestGetConfigWithDefaults(unittest.TestCase):
@@ -66,12 +66,12 @@ class TestGetConfigWithDefaults(unittest.TestCase):
         conf = config.get_config('tests/test-config/valid-partial-config.yaml')
         default_cookiecutters_dir = os.path.expanduser('~/.cookiecutters/')
         expected_conf = {
-        	'cookiecutters_dir': default_cookiecutters_dir,
-        	'default_context': {
-        		"full_name": "Firstname Lastname",
-        		"email": "firstname.lastname@gmail.com",
-        		"github_username": "example"
-        	}
+                'cookiecutters_dir': default_cookiecutters_dir,
+                'default_context': {
+                        'full_name': 'Firstname Lastname',
+                        'email': 'firstname.lastname@gmail.com',
+                        'github_username': 'example'
+                }
         }
         self.assertEqual(conf, expected_conf)
 
@@ -101,12 +101,12 @@ class TestGetUserConfig(unittest.TestCase):
         shutil.copy('tests/test-config/valid-config.yaml', self.user_config_path)
         conf = config.get_user_config()
         expected_conf = {
-        	'cookiecutters_dir': '/home/example/some-path-to-templates',
-        	'default_context': {
-        		"full_name": "Firstname Lastname",
-        		"email": "firstname.lastname@gmail.com",
-        		"github_username": "example"
-        	}
+                'cookiecutters_dir': '/home/example/some-path-to-templates',
+                'default_context': {
+                        'full_name': 'Firstname Lastname',
+                        'email': 'firstname.lastname@gmail.com',
+                        'github_username': 'example'
+                }
         }
         self.assertEqual(conf, expected_conf)
 
@@ -135,9 +135,9 @@ class TestGetUserConfigFromEnv(unittest.TestCase):
             os.remove(self.user_config_path)
 
         # Save and clear out cookiecutter's environment variables
-        self.cookiecutter_config = os.environ.get("COOKIECUTTER_CONFIG")
-        if "COOKIECUTTER_CONFIG" in os.environ:
-            del os.environ["COOKIECUTTER_CONFIG"]
+        self.cookiecutter_config = os.environ.get('COOKIECUTTER_CONFIG')
+        if 'COOKIECUTTER_CONFIG' in os.environ:
+            del os.environ['COOKIECUTTER_CONFIG']
 
     def tearDown(self):
         # If it existed, restore ~/.cookiecutterrc
@@ -146,33 +146,33 @@ class TestGetUserConfigFromEnv(unittest.TestCase):
             os.remove(self.user_config_path_backup)
 
         # Restore any saved cookiecutter environment variables
-        if "COOKIECUTTER_CONFIG" in os.environ:
-            del os.environ["COOKIECUTTER_CONFIG"]
+        if 'COOKIECUTTER_CONFIG' in os.environ:
+            del os.environ['COOKIECUTTER_CONFIG']
         if self.cookiecutter_config is not None:
-            os.environ["COOKIECUTTER_CONFIG"] = self.cookiecutter_config
+            os.environ['COOKIECUTTER_CONFIG'] = self.cookiecutter_config
 
     def test_get_env_config_valid(self):
         """ Environment variable specifies a valid ~/.cookiecutterrc file"""
-        os.environ["COOKIECUTTER_CONFIG"] = 'tests/test-config/valid-config.yaml'
+        os.environ['COOKIECUTTER_CONFIG'] = 'tests/test-config/valid-config.yaml'
         conf = config.get_user_config()
         expected_conf = {
                 'cookiecutters_dir': '/home/example/some-path-to-templates',
                 'default_context': {
-                        "full_name": "Firstname Lastname",
-                        "email": "firstname.lastname@gmail.com",
-                        "github_username": "example"
+                        'full_name': 'Firstname Lastname',
+                        'email': 'firstname.lastname@gmail.com',
+                        'github_username': 'example'
                 }
         }
         self.assertEqual(conf, expected_conf)
 
     def test_get_env_config_invalid(self):
         """ Environment variable specifies an invalid .cookiecutterrc file"""
-        os.environ["COOKIECUTTER_CONFIG"] = 'tests/test-config/invalid-config.yaml'
+        os.environ['COOKIECUTTER_CONFIG'] = 'tests/test-config/invalid-config.yaml'
         self.assertRaises(InvalidConfiguration, config.get_user_config)
 
     def test_get_env_config_nonexistent(self):
         """ The file specified in COOKIECUTTER_CONFIG does not exist """
-        os.environ["COOKIECUTTER_CONFIG"] = 'tests/nonexistent-config.yaml'
+        os.environ['COOKIECUTTER_CONFIG'] = 'tests/nonexistent-config.yaml'
         self.assertEqual(config.get_user_config(), config.DEFAULT_CONFIG)
 
 


### PR DESCRIPTION
Apart from being useful for users, this will allow us to test more easily, without having to save/restore the user's config as much as we currently do.