### PR TITLE
Support a new YAML format for template settings

### DIFF
--- a/cookiecutter/exceptions.py
+++ b/cookiecutter/exceptions.py
@@ -51,3 +51,13 @@ class UnknownRepoType(CookiecutterException):
     """
     Raised if a repo's type cannot be determined.
     """
+
+class MissingTemplateSettingsException(CookiecutterException):
+    """
+    Raised if a repo has no settings file
+    """
+
+class MultipleTemplateSettingsException(CookiecutterException):
+    """
+    Raised if a repo has both YAML and JSON settings files
+    """

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -33,35 +33,6 @@ else:
     from collections import OrderedDict
 
 
-def generate_context(context_file='cookiecutter.json', default_context=None):
-    """
-    Generates the context for a Cookiecutter project template.
-    Loads the JSON file as a Python object, with key being the JSON filename.
-
-    :param context_file: JSON file containing key/value pairs for populating
-        the cookiecutter's variables.
-    :param config_dict: Dict containing any config to take into account.
-    """
-
-    context = {}
-
-    file_handle = open(context_file)
-    obj = json.load(file_handle, object_pairs_hook=OrderedDict)
-
-    # Add the Python object to the context dictionary
-    file_name = os.path.split(context_file)[1]
-    file_stem = file_name.split('.')[0]
-    context[file_stem] = obj
-
-    # Overwrite context variable defaults with the default context from the
-    # user's global config, if available
-    if default_context:
-        obj.update(default_context)
-
-    logging.debug('Context generated is {0}'.format(context))
-    return context
-
-
 def generate_file(project_dir, infile, context, env):
     """
     1. Render the filename of infile as the name of outfile.

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -20,7 +20,8 @@ import sys
 from . import __version__
 from .config import get_user_config
 from .prompt import prompt_for_config
-from .generate import generate_context, generate_files
+from .generate import generate_files
+from .settings import get_settings, get_context_from_settings
 from .vcs import clone
 
 logger = logging.getLogger(__name__)
@@ -50,13 +51,14 @@ def cookiecutter(input_dir, checkout=None, no_input=False):
         # If it's a local repo, no need to clone or copy to your cookiecutters_dir
         repo_dir = input_dir
 
-    context_file = os.path.join(repo_dir, 'cookiecutter.json')
+    context_file = os.path.join(repo_dir, 'cookiecutter')
     logging.debug('context_file is {0}'.format(context_file))
 
-    context = generate_context(
-        context_file=context_file,
+    template_settings = get_settings(
+        name=context_file,
         default_context=config_dict['default_context']
     )
+    context = get_context_from_settings(template_settings)
 
     # prompt the user to manually configure at the command line.
     # except when 'no-input' flag is set

--- a/cookiecutter/settings.py
+++ b/cookiecutter/settings.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+cookiecutter.settings
+---------------------
+
+Handling of template settings files
+"""
+
+import os
+import io
+import sys
+
+import yaml
+
+from .exceptions import MultipleTemplateSettingsException, MissingTemplateSettingsException
+
+
+if sys.version_info[:2] < (2, 7):
+    import simplejson as json
+    from ordereddict import OrderedDict
+else:
+    import json
+    from collections import OrderedDict
+
+
+def get_default_settings(version=2):
+    return {'config': {'version': version}, 'context': {}}
+
+
+def get_settings(name, default_context=None):
+    """Get template settings from a YAML or JSON file"""
+
+    stem = os.path.basename(name)
+    yaml_file = name + '.yaml'
+    json_file = name + '.json'
+
+    # Check whether there is a YAML file or a JSON file, and load it.
+    # Having both is an error, having neither gives the default.
+    # TODO: Should having neither be an error?
+    if os.path.exists(yaml_file) and os.path.exists(json_file):
+        raise MultipleTemplateSettingsException
+    elif os.path.exists(yaml_file):
+        settings = get_yaml_settings(yaml_file)
+    elif os.path.exists(json_file):
+        settings = get_json_settings(json_file)
+    else:
+        raise MissingTemplateSettingsException
+
+    # Use the default_context argument to override values in the context
+    if default_context:
+        settings['context'].update(default_context)
+
+    # The context from the file should be under the filename stem as a key
+    settings['context'] = {stem: settings['context']}
+
+    return settings
+
+
+def get_context_from_settings(settings):
+    """Get the context part of the settings.
+
+    Trivial at the moment, but will become more complex when we have context
+    metadata like types and prompts.
+    """
+    return settings['context']
+
+
+def get_yaml_settings(name):
+    with open(name, 'rb') as f:
+        return yaml.load(f)
+
+
+def get_json_settings(name):
+    with io.open(name, encoding='utf-8') as f:
+        # The JSON file just contains the context.
+        context = json.load(f, object_pairs_hook=OrderedDict)
+        settings = get_default_settings(version=1)
+        settings['context'] = context
+        return settings

--- a/cookiecutter/settings.py
+++ b/cookiecutter/settings.py
@@ -25,10 +25,6 @@ else:
     from collections import OrderedDict
 
 
-def get_default_settings(version=2):
-    return {'config': {'version': version}, 'context': {}}
-
-
 def get_settings(name, default_context=None):
     """Get template settings from a YAML or JSON file"""
 
@@ -37,8 +33,7 @@ def get_settings(name, default_context=None):
     json_file = name + '.json'
 
     # Check whether there is a YAML file or a JSON file, and load it.
-    # Having both is an error, having neither gives the default.
-    # TODO: Should having neither be an error?
+    # Having both (or neither) is an error.
     if os.path.exists(yaml_file) and os.path.exists(json_file):
         raise MultipleTemplateSettingsException
     elif os.path.exists(yaml_file):
@@ -48,12 +43,15 @@ def get_settings(name, default_context=None):
     else:
         raise MissingTemplateSettingsException
 
+    # Make sure we have a context
+    ctx = settings.get('context', {})
+
     # Use the default_context argument to override values in the context
     if default_context:
-        settings['context'].update(default_context)
+        ctx.update(default_context)
 
     # The context from the file should be under the filename stem as a key
-    settings['context'] = {stem: settings['context']}
+    settings['context'] = {stem: ctx}
 
     return settings
 
@@ -67,12 +65,32 @@ def get_context_from_settings(settings):
     return settings['context']
 
 
+def get_version_from_settings(settings):
+    """Get the version of the settings format."""
+    try:
+        return int(settings['config']['version'])
+    except KeyError:
+        # YAML format with no config/version element
+        return 2
+
+
+# Private implementation details
+
+
+def get_default_settings(version=2):
+    return {'config': {'version': version}, 'context': {}}
+
+
 def get_yaml_settings(name):
+    # yaml.load will take a file opened in binary mode, and deduce the encoding (one of
+    # utf8, utf16le or utf16be)
     with open(name, 'rb') as f:
-        return yaml.load(f)
+        # An empty YAML file is returned as None - so return an empty dict in that case
+        return yaml.load(f) or {}
 
 
 def get_json_settings(name):
+    # json.load expects a file open in text mode. We require the file to be utf8 encoded.
     with io.open(name, encoding='utf-8') as f:
         # The JSON file just contains the context.
         context = json.load(f, object_pairs_hook=OrderedDict)

--- a/tests/test-settings/both.json
+++ b/tests/test-settings/both.json
@@ -1,0 +1,5 @@
+{
+    "full_name": "Firstname Lastname",
+    "email": "firstname.lastname@gmail.com",
+    "github_username": "example"
+}

--- a/tests/test-settings/both.yaml
+++ b/tests/test-settings/both.yaml
@@ -1,0 +1,6 @@
+config:
+    version: 2
+context:
+    full_name: Firstname Lastname
+    email: firstname.lastname@gmail.com
+    github_username: example

--- a/tests/test-settings/valid-json.json
+++ b/tests/test-settings/valid-json.json
@@ -1,0 +1,5 @@
+{
+    "full_name": "Firstname Lastname",
+    "email": "firstname.lastname@gmail.com",
+    "github_username": "example"
+}

--- a/tests/test-settings/valid.yaml
+++ b/tests/test-settings/valid.yaml
@@ -1,0 +1,6 @@
+config:
+    version: 2
+context:
+    full_name: Firstname Lastname
+    email: firstname.lastname@gmail.com
+    github_username: example

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -22,6 +22,7 @@ from jinja2.exceptions import TemplateSyntaxError
 from cookiecutter import generate
 from cookiecutter import exceptions
 from cookiecutter import utils
+from cookiecutter import settings
 from tests import CookiecutterCleanSystemTestCase
 
 
@@ -191,16 +192,18 @@ class TestGenerateFiles(CookiecutterCleanSystemTestCase):
 class TestGenerateContext(CookiecutterCleanSystemTestCase):
 
     def test_generate_context(self):
-        context = generate.generate_context(
-            context_file='tests/test-generate-context/test.json'
+        template_settings = settings.get_settings(
+            'tests/test-generate-context/test'
         )
+        context = settings.get_context_from_settings(template_settings)
         self.assertEqual(context, {"test": {"1": 2, "some_key": "some_val"}})
 
     def test_generate_context_with_default(self):
-        context = generate.generate_context(
-            context_file='tests/test-generate-context/test.json',
+        template_settings = settings.get_settings(
+            'tests/test-generate-context/test',
             default_context={"1": 3}
         )
+        context = settings.get_context_from_settings(template_settings)
         self.assertEqual(context, {"test": {"1": 3, "some_key": "some_val"}})
 
 
@@ -212,9 +215,10 @@ class TestOutputFolder(CookiecutterCleanSystemTestCase):
         super(TestOutputFolder, self).tearDown()
 
     def test_output_folder(self):
-        context = generate.generate_context(
-            context_file='tests/test-output-folder/cookiecutter.json'
+        template_settings = settings.get_settings(
+            'tests/test-output-folder/cookiecutter'
         )
+        context = settings.get_context_from_settings(template_settings)
         logging.debug('Context is {0}'.format(context))
         generate.generate_files(
             context=context,

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -8,10 +8,14 @@ test_settings
 Tests for `cookiecutter.settings` module.
 """
 
+import os
 import sys
+import tempfile
+from contextlib import contextmanager
 
 from cookiecutter import settings
 from cookiecutter import exceptions
+
 
 if sys.version_info[:2] < (2, 7):
     import unittest2 as unittest
@@ -19,33 +23,45 @@ else:
     import unittest
 
 
+@contextmanager
+def temp(content=None, suffix='.yaml'):
+    name = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as f:
+            if content:
+                f.write(content.encode('utf-8'))
+            name = f.name
+        yield name[:-len(suffix)]
+    finally:
+        if name and os.path.exists(name):
+            os.unlink(name)
+
+
 class TestGetConfig(unittest.TestCase):
 
     def test_get_settings(self):
         """ Opening and reading settings file """
-        stg = settings.get_settings('tests/test-settings/valid')
+        template_settings = settings.get_settings(name='tests/test-settings/valid')
         expected_context = {
-            'full_name': 'Firstname Lastname',
-            'email': 'firstname.lastname@gmail.com',
-            'github_username': 'example'
+            'valid': {
+                'full_name': 'Firstname Lastname',
+                'email': 'firstname.lastname@gmail.com',
+                'github_username': 'example'
+            }
         }
-        self.assertTrue('config' in stg)
-        self.assertTrue('context' in stg)
-        self.assertEqual(stg['config'].get('version'), 2)
-        self.assertEqual(stg['context'].get('valid'), expected_context)
+        self.assertEqual(settings.get_context_from_settings(template_settings), expected_context)
 
     def test_get_settings_json(self):
         """ Opening and reading old-style JSON settings file """
-        stg = settings.get_settings('tests/test-settings/valid-json')
+        template_settings = settings.get_settings('tests/test-settings/valid-json')
         expected_context = {
-            'full_name': 'Firstname Lastname',
-            'email': 'firstname.lastname@gmail.com',
-            'github_username': 'example'
+            'valid-json': {
+                'full_name': 'Firstname Lastname',
+                'email': 'firstname.lastname@gmail.com',
+                'github_username': 'example'
+            }
         }
-        self.assertTrue('config' in stg)
-        self.assertTrue('context' in stg)
-        self.assertEqual(stg['config'].get('version'), 1)
-        self.assertEqual(stg['context'].get('valid-json'), expected_context)
+        self.assertEqual(settings.get_context_from_settings(template_settings), expected_context)
 
     def test_get_settings_does_not_exist(self):
         """
@@ -66,6 +82,30 @@ class TestGetConfig(unittest.TestCase):
             settings.get_settings,
             'tests/test-settings/both'
         )
+
+    def test_version_of_empty_yaml_is_2(self):
+        """
+        Check that an empty YAML file is reported as version 2
+        """
+        with temp('') as name:
+            template_settings = settings.get_settings(name)
+            self.assertEqual(settings.get_version_from_settings(template_settings), 2)
+
+    def test_version_is_read_from_yaml(self):
+        """
+        Check that an explicit version is read from a YAML file
+        """
+        with temp('config:\n    version: 3') as name:
+            template_settings = settings.get_settings(name)
+            self.assertEqual(settings.get_version_from_settings(template_settings), 3)
+
+    def test_json_version_is_1(self):
+        """
+        Check that a JSON format file is reported as version 1
+        """
+        with temp('{}', suffix='.json') as name:
+            template_settings = settings.get_settings(name)
+            self.assertEqual(settings.get_version_from_settings(template_settings), 1)
 
 
 if __name__ == '__main__':

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_settings
+-------------
+
+Tests for `cookiecutter.settings` module.
+"""
+
+import sys
+
+from cookiecutter import settings
+from cookiecutter import exceptions
+
+if sys.version_info[:2] < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+class TestGetConfig(unittest.TestCase):
+
+    def test_get_settings(self):
+        """ Opening and reading settings file """
+        stg = settings.get_settings('tests/test-settings/valid')
+        expected_context = {
+            'full_name': 'Firstname Lastname',
+            'email': 'firstname.lastname@gmail.com',
+            'github_username': 'example'
+        }
+        self.assertTrue('config' in stg)
+        self.assertTrue('context' in stg)
+        self.assertEqual(stg['config'].get('version'), 2)
+        self.assertEqual(stg['context'].get('valid'), expected_context)
+
+    def test_get_settings_json(self):
+        """ Opening and reading old-style JSON settings file """
+        stg = settings.get_settings('tests/test-settings/valid-json')
+        expected_context = {
+            'full_name': 'Firstname Lastname',
+            'email': 'firstname.lastname@gmail.com',
+            'github_username': 'example'
+        }
+        self.assertTrue('config' in stg)
+        self.assertTrue('context' in stg)
+        self.assertEqual(stg['config'].get('version'), 1)
+        self.assertEqual(stg['context'].get('valid-json'), expected_context)
+
+    def test_get_settings_does_not_exist(self):
+        """
+        Check that a missing settings file results in an exception.
+        """
+        self.assertRaises(
+            exceptions.MissingTemplateSettingsException,
+            settings.get_settings,
+            'tests/test-settings/does-not-exist'
+        )
+
+    def test_get_settings_both_formats_exist(self):
+        """
+        Check that you cannot have both settings formats present.
+        """
+        self.assertRaises(
+            exceptions.MultipleTemplateSettingsException,
+            settings.get_settings,
+            'tests/test-settings/both'
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
This is the initial version of support for a YAML format settings file, to supersede ```cookiecutter.json```. Before committing, I would like to refactor this further, to make the "internal" format completely encapsulated in ```settings.py``` so that client code need have no knowledge of how the settings are stored. But the PR is sufficiently complete that it's ready for initial review.

At the moment, it's only the context data that is in the settings, so the refactoring won't actually impact much, but it establishes the principle that following changes should follow. The main change at this stage will be in the tests, which currently know far too much about how the settings/context is stored.