### PR TITLE
Add config prompt design inspired by bower and npm

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -30,7 +30,7 @@ def prompt_for_config(context, no_input=False):
         val = env.from_string(raw).render(cookiecutter=cookiecutter_dict)
 
         if not no_input:
-            prompt = '{0} (default is "{1}")? '.format(key, val)
+            prompt = "{key}: ({default}) ".format(key=key, default=val)
 
             new_val = read_response(prompt).strip()
 


### PR DESCRIPTION
Note: the original PR (#207) was botched - this is my second attempt.

---

Very simple update (no changes to code execution) and therefor no added tests.

Simply a cleaner config prompt, inspired by bower and npm.

Before: `full_name (default is "Your full name")?`
After: `full_name: (Your full name)`

/cc @michaeljoseph 

EDIT: updated prompt preview to reflect discussion below, removed prepended `[?]`.
