### PR TITLE
Hackebrot convert test cookiecutter local no input

### DIFF
--- a/tests/test_cookiecutter_local_no_input.py
+++ b/tests/test_cookiecutter_local_no_input.py
@@ -21,7 +21,7 @@ from cookiecutter import main, utils
 @pytest.fixture(scope='function')
 def remove_additional_dirs(request):
     """
-    Remove special directories which are creating during the tests.
+    Remove special directories which are created during the tests.
     """
     def fin_remove_additional_dirs():
         if os.path.isdir('fake-project'):

--- a/tests/test_cookiecutter_local_no_input.py
+++ b/tests/test_cookiecutter_local_no_input.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_cookiecutter_local_no_input
+--------------------------------
+
+Tests formerly known from a unittest residing in test_main.py named
+TestCookiecutterLocalNoInput.test_cookiecutter
+"""
+
+import os
+import pytest
+
+from cookiecutter import main, utils
+
+
+@pytest.fixture(scope='function')
+def remove_additional_dirs(request):
+    """
+    Remove special directories which are creating during the tests.
+    """
+    def fin_remove_additional_dirs():
+        if os.path.isdir('fake-project'):
+            utils.rmtree('fake-project')
+        if os.path.isdir('fake-project-extra'):
+            utils.rmtree('fake-project-extra')
+        if os.path.isdir('fake-project-templated'):
+            utils.rmtree('fake-project-templated')
+    request.addfinalizer(fin_remove_additional_dirs)
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_additional_dirs')
+def test_cookiecutter():
+    main.cookiecutter('tests/fake-repo-pre/', no_input=True)
+    assert os.path.isdir('tests/fake-repo-pre/{{cookiecutter.repo_name}}')
+    assert not os.path.isdir('tests/fake-repo-pre/fake-project')
+    assert os.path.isdir('fake-project')
+    assert os.path.isfile('fake-project/README.rst')
+    assert not os.path.exists('fake-project/json/')

--- a/tests/test_cookiecutter_local_no_input.py
+++ b/tests/test_cookiecutter_local_no_input.py
@@ -8,6 +8,7 @@ test_cookiecutter_local_no_input
 Tests formerly known from a unittest residing in test_main.py named
 TestCookiecutterLocalNoInput.test_cookiecutter
 TestCookiecutterLocalNoInput.test_cookiecutter_no_slash
+TestCookiecutterLocalNoInput.test_cookiecutter_no_input_extra_context
 """
 
 import os
@@ -46,3 +47,16 @@ def test_cookiecutter():
     assert os.path.isdir('fake-project')
     assert os.path.isfile('fake-project/README.rst')
     assert not os.path.exists('fake-project/json/')
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_additional_dirs')
+def test_cookiecutter_no_input_extra_context():
+    """
+    `Call cookiecutter()` with `no_input=True` and `extra_context
+    """
+    main.cookiecutter(
+        'tests/fake-repo-pre',
+        no_input=True,
+        extra_context={'repo_name': 'fake-project-extra'}
+    )
+    assert os.path.isdir('fake-project-extra')

--- a/tests/test_cookiecutter_local_no_input.py
+++ b/tests/test_cookiecutter_local_no_input.py
@@ -9,6 +9,7 @@ Tests formerly known from a unittest residing in test_main.py named
 TestCookiecutterLocalNoInput.test_cookiecutter
 TestCookiecutterLocalNoInput.test_cookiecutter_no_slash
 TestCookiecutterLocalNoInput.test_cookiecutter_no_input_extra_context
+TestCookiecutterLocalNoInput.test_cookiecutter_templated_context
 """
 
 import os
@@ -60,3 +61,16 @@ def test_cookiecutter_no_input_extra_context():
         extra_context={'repo_name': 'fake-project-extra'}
     )
     assert os.path.isdir('fake-project-extra')
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_additional_dirs')
+def test_cookiecutter_templated_context():
+    """
+    `Call cookiecutter()` with `no_input=True` and templates in the
+    cookiecutter.json file
+    """
+    main.cookiecutter(
+        'tests/fake-repo-tmpl',
+        no_input=True
+    )
+    assert os.path.isdir('fake-project-templated')

--- a/tests/test_cookiecutter_local_no_input.py
+++ b/tests/test_cookiecutter_local_no_input.py
@@ -7,6 +7,7 @@ test_cookiecutter_local_no_input
 
 Tests formerly known from a unittest residing in test_main.py named
 TestCookiecutterLocalNoInput.test_cookiecutter
+TestCookiecutterLocalNoInput.test_cookiecutter_no_slash
 """
 
 import os
@@ -30,9 +31,16 @@ def remove_additional_dirs(request):
     request.addfinalizer(fin_remove_additional_dirs)
 
 
-@pytest.mark.usefixtures('clean_system', 'remove_additional_dirs')
+@pytest.fixture(params=['tests/fake-repo-pre/', 'tests/fake-repo-pre'])
+def bake(request):
+    """
+    Run cookiecutter with the given input_dir path.
+    """
+    main.cookiecutter(request.param, no_input=True)
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_additional_dirs', 'bake')
 def test_cookiecutter():
-    main.cookiecutter('tests/fake-repo-pre/', no_input=True)
     assert os.path.isdir('tests/fake-repo-pre/{{cookiecutter.repo_name}}')
     assert not os.path.isdir('tests/fake-repo-pre/fake-project')
     assert os.path.isdir('fake-project')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -26,14 +26,6 @@ logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 
 class TestCookiecutterLocalNoInput(CookiecutterCleanSystemTestCase):
 
-    def test_cookiecutter_no_slash(self):
-        main.cookiecutter('tests/fake-repo-pre', no_input=True)
-        self.assertTrue(os.path.isdir('tests/fake-repo-pre/{{cookiecutter.repo_name}}'))
-        self.assertFalse(os.path.isdir('tests/fake-repo-pre/fake-project'))
-        self.assertTrue(os.path.isdir('fake-project'))
-        self.assertTrue(os.path.isfile('fake-project/README.rst'))
-        self.assertFalse(os.path.exists('fake-project/json/'))
-
     def test_cookiecutter_no_input_extra_context(self):
         """ `Call cookiecutter()` with `no_input=True` and `extra_context` """
         main.cookiecutter(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,28 +24,6 @@ except KeyError:
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 
 
-class TestCookiecutterLocalNoInput(CookiecutterCleanSystemTestCase):
-
-    def test_cookiecutter_templated_context(self):
-        """
-        `Call cookiecutter()` with `no_input=True` and templates in the
-        cookiecutter.json file
-        """
-        main.cookiecutter(
-            'tests/fake-repo-tmpl',
-            no_input=True
-        )
-        self.assertTrue(os.path.isdir('fake-project-templated'))
-
-    def tearDown(self):
-        if os.path.isdir('fake-project'):
-            utils.rmtree('fake-project')
-        if os.path.isdir('fake-project-extra'):
-            utils.rmtree('fake-project-extra')
-        if os.path.isdir('fake-project-templated'):
-            utils.rmtree('fake-project-templated')
-
-
 class TestCookiecutterLocalWithInput(CookiecutterCleanSystemTestCase):
 
     @patch('cookiecutter.prompt.read_response', lambda x=u'': u'\n')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -26,15 +26,6 @@ logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 
 class TestCookiecutterLocalNoInput(CookiecutterCleanSystemTestCase):
 
-    def test_cookiecutter_no_input_extra_context(self):
-        """ `Call cookiecutter()` with `no_input=True` and `extra_context` """
-        main.cookiecutter(
-            'tests/fake-repo-pre',
-            no_input=True,
-            extra_context={'repo_name': 'fake-project-extra'}
-        )
-        self.assertTrue(os.path.isdir('fake-project-extra'))
-
     def test_cookiecutter_templated_context(self):
         """
         `Call cookiecutter()` with `no_input=True` and templates in the

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -26,14 +26,6 @@ logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 
 class TestCookiecutterLocalNoInput(CookiecutterCleanSystemTestCase):
 
-    def test_cookiecutter(self):
-        main.cookiecutter('tests/fake-repo-pre/', no_input=True)
-        self.assertTrue(os.path.isdir('tests/fake-repo-pre/{{cookiecutter.repo_name}}'))
-        self.assertFalse(os.path.isdir('tests/fake-repo-pre/fake-project'))
-        self.assertTrue(os.path.isdir('fake-project'))
-        self.assertTrue(os.path.isfile('fake-project/README.rst'))
-        self.assertFalse(os.path.exists('fake-project/json/'))
-
     def test_cookiecutter_no_slash(self):
         main.cookiecutter('tests/fake-repo-pre', no_input=True)
         self.assertTrue(os.path.isdir('tests/fake-repo-pre/{{cookiecutter.repo_name}}'))


### PR DESCRIPTION
Convert `test_main.TestCookiecutterLocalNoInput` to `py.test` syntax this time using a parametrized fixture for two of the tests (slash/no-slash).