### PR TITLE
Hackebrot convert test cookiecutter local with input

### DIFF
--- a/tests/test_cookiecutter_local_with_input.py
+++ b/tests/test_cookiecutter_local_with_input.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 """
-test_cookiecutter_local_no_input
---------------------------------
+test_cookiecutter_local_with_input
+----------------------------------
 
 Tests formerly known from a unittest residing in test_main.py named
 TestCookiecutterLocalWithInput.test_cookiecutter_local_with_input

--- a/tests/test_cookiecutter_local_with_input.py
+++ b/tests/test_cookiecutter_local_with_input.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_cookiecutter_local_no_input
+--------------------------------
+
+Tests formerly known from a unittest residing in test_main.py named
+TestCookiecutterLocalWithInput.test_cookiecutter_local_with_input
+"""
+
+import os
+import pytest
+
+from cookiecutter import main, utils
+
+
+@pytest.fixture(scope='function')
+def remove_additional_dirs(request):
+    """
+    Remove special directories which are created during the tests.
+    """
+    def fin_remove_additional_dirs():
+        if os.path.isdir('fake-project'):
+            utils.rmtree('fake-project')
+        if os.path.isdir('fake-project-input-extra'):
+            utils.rmtree('fake-project-input-extra')
+    request.addfinalizer(fin_remove_additional_dirs)
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_additional_dirs')
+def test_cookiecutter_local_with_input(monkeypatch):
+    monkeypatch.setattr(
+        'cookiecutter.prompt.read_response',
+        lambda x=u'': u'\n'
+    )
+    main.cookiecutter('tests/fake-repo-pre/', no_input=False)
+    assert os.path.isdir('tests/fake-repo-pre/{{cookiecutter.repo_name}}')
+    assert not os.path.isdir('tests/fake-repo-pre/fake-project')
+    assert os.path.isdir('fake-project')
+    assert os.path.isfile('fake-project/README.rst')
+    assert not os.path.exists('fake-project/json/')

--- a/tests/test_cookiecutter_local_with_input.py
+++ b/tests/test_cookiecutter_local_with_input.py
@@ -7,6 +7,7 @@ test_cookiecutter_local_no_input
 
 Tests formerly known from a unittest residing in test_main.py named
 TestCookiecutterLocalWithInput.test_cookiecutter_local_with_input
+TestCookiecutterLocalWithInput.test_cookiecutter_input_extra_context
 """
 
 import os
@@ -40,3 +41,20 @@ def test_cookiecutter_local_with_input(monkeypatch):
     assert os.path.isdir('fake-project')
     assert os.path.isfile('fake-project/README.rst')
     assert not os.path.exists('fake-project/json/')
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_additional_dirs')
+def test_cookiecutter_input_extra_context(monkeypatch):
+    """
+    `Call cookiecutter()` with `no_input=False` and `extra_context`
+    """
+    monkeypatch.setattr(
+        'cookiecutter.prompt.read_response',
+        lambda x=u'': u'\n'
+    )
+    main.cookiecutter(
+        'tests/fake-repo-pre',
+        no_input=True,
+        extra_context={'repo_name': 'fake-project-input-extra'}
+    )
+    assert os.path.isdir('fake-project-input-extra')

--- a/tests/test_cookiecutter_local_with_input.py
+++ b/tests/test_cookiecutter_local_with_input.py
@@ -54,7 +54,7 @@ def test_cookiecutter_input_extra_context(monkeypatch):
     )
     main.cookiecutter(
         'tests/fake-repo-pre',
-        no_input=True,
+        no_input=False,
         extra_context={'repo_name': 'fake-project-input-extra'}
     )
     assert os.path.isdir('fake-project-input-extra')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,11 +14,6 @@ import unittest
 
 from cookiecutter import main
 
-try:
-    no_network = os.environ[u'DISABLE_NETWORK_TESTS']
-except KeyError:
-    no_network = False
-
 # Log debug and above to console
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -71,25 +71,6 @@ class TestCookiecutterLocalNoInput(CookiecutterCleanSystemTestCase):
             utils.rmtree('fake-project-templated')
 
 
-class TestCookiecutterLocalWithInput(CookiecutterCleanSystemTestCase):
-
-    @patch('cookiecutter.prompt.read_response', lambda x=u'': u'\n')
-    def test_cookiecutter_input_extra_context(self):
-        """ `Call cookiecutter()` with `no_input=False` and `extra_context` """
-        main.cookiecutter(
-            'tests/fake-repo-pre',
-            no_input=True,
-            extra_context={'repo_name': 'fake-project-input-extra'}
-        )
-        self.assertTrue(os.path.isdir('fake-project-input-extra'))
-
-    def tearDown(self):
-        if os.path.isdir('fake-project'):
-            utils.rmtree('fake-project')
-        if os.path.isdir('fake-project-input-extra'):
-            utils.rmtree('fake-project-input-extra')
-
-
 class TestArgParsing(unittest.TestCase):
 
     def test_parse_cookiecutter_args(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -25,34 +25,6 @@ except KeyError:
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 
 
-class TestCookiecutterLocalWithInput(CookiecutterCleanSystemTestCase):
-
-    @patch('cookiecutter.prompt.read_response', lambda x=u'': u'\n')
-    def test_cookiecutter_local_with_input(self):
-        main.cookiecutter('tests/fake-repo-pre/', no_input=False)
-        self.assertTrue(os.path.isdir('tests/fake-repo-pre/{{cookiecutter.repo_name}}'))
-        self.assertFalse(os.path.isdir('tests/fake-repo-pre/fake-project'))
-        self.assertTrue(os.path.isdir('fake-project'))
-        self.assertTrue(os.path.isfile('fake-project/README.rst'))
-        self.assertFalse(os.path.exists('fake-project/json/'))
-
-    @patch('cookiecutter.prompt.read_response', lambda x=u'': u'\n')
-    def test_cookiecutter_input_extra_context(self):
-        """ `Call cookiecutter()` with `no_input=False` and `extra_context` """
-        main.cookiecutter(
-            'tests/fake-repo-pre',
-            no_input=True,
-            extra_context={'repo_name': 'fake-project-input-extra'}
-        )
-        self.assertTrue(os.path.isdir('fake-project-input-extra'))
-
-    def tearDown(self):
-        if os.path.isdir('fake-project'):
-            utils.rmtree('fake-project')
-        if os.path.isdir('fake-project-input-extra'):
-            utils.rmtree('fake-project-input-extra')
-
-
 class TestAbbreviationExpansion(unittest.TestCase):
 
     def test_abbreviation_expansion(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,7 +9,6 @@ Tests for `cookiecutter.main` module.
 """
 
 import logging
-import os
 import unittest
 
 from cookiecutter import main

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -74,15 +74,6 @@ class TestCookiecutterLocalNoInput(CookiecutterCleanSystemTestCase):
 class TestCookiecutterLocalWithInput(CookiecutterCleanSystemTestCase):
 
     @patch('cookiecutter.prompt.read_response', lambda x=u'': u'\n')
-    def test_cookiecutter_local_with_input(self):
-        main.cookiecutter('tests/fake-repo-pre/', no_input=False)
-        self.assertTrue(os.path.isdir('tests/fake-repo-pre/{{cookiecutter.repo_name}}'))
-        self.assertFalse(os.path.isdir('tests/fake-repo-pre/fake-project'))
-        self.assertTrue(os.path.isdir('fake-project'))
-        self.assertTrue(os.path.isfile('fake-project/README.rst'))
-        self.assertFalse(os.path.exists('fake-project/json/'))
-
-    @patch('cookiecutter.prompt.read_response', lambda x=u'': u'\n')
     def test_cookiecutter_input_extra_context(self):
         """ `Call cookiecutter()` with `no_input=False` and `extra_context` """
         main.cookiecutter(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,9 +12,7 @@ import logging
 import os
 import unittest
 
-from cookiecutter.compat import patch
-from cookiecutter import main, utils
-from tests import CookiecutterCleanSystemTestCase
+from cookiecutter import main
 
 try:
     no_network = os.environ[u'DISABLE_NETWORK_TESTS']


### PR DESCRIPTION
Convert `test_main.TestCookiecutterLocalWithInput` using `monkeypatch` of `py.test`.

According to the name of the original name and the doc string of `test_cookiecutter_input_extra_context` the `no_input` argument needs to be `False`, so I changed the former version.

Please let me know if this is correct.