### PR TITLE
Hackebrot test arg parsing

### DIFF
--- a/tests/test_arg_parsing.py
+++ b/tests/test_arg_parsing.py
@@ -18,7 +18,7 @@ from cookiecutter import main
 def test_parse_cookiecutter_args():
     args = main.parse_cookiecutter_args(['project/'])
     assert args.input_dir == 'project/'
-    assert args.checkout == None
+    assert args.checkout is None
 
 
 def test_parse_cookiecutter_args_with_branch():

--- a/tests/test_arg_parsing.py
+++ b/tests/test_arg_parsing.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_arg_parsing
+----------------
+
+Tests formerly known from a unittest residing in test_main.py named
+TestArgParsing.test_parse_cookiecutter_args
+TestArgParsing.test_parse_cookiecutter_args_with_branch
+"""
+
+from __future__ import unicode_literals
+
+from cookiecutter import main
+
+
+def test_parse_cookiecutter_args():
+    args = main.parse_cookiecutter_args(['project/'])
+    assert args.input_dir == 'project/'
+    assert args.checkout == None
+
+
+def test_parse_cookiecutter_args_with_branch():
+    args = main.parse_cookiecutter_args(['project/', '--checkout', 'develop'])
+    assert args.input_dir == 'project/'
+    assert args.checkout == 'develop'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -99,19 +99,6 @@ class TestCookiecutterLocalWithInput(CookiecutterCleanSystemTestCase):
             utils.rmtree('fake-project-input-extra')
 
 
-class TestArgParsing(unittest.TestCase):
-
-    def test_parse_cookiecutter_args(self):
-        args = main.parse_cookiecutter_args(['project/'])
-        self.assertEqual(args.input_dir, 'project/')
-        self.assertEqual(args.checkout, None)
-
-    def test_parse_cookiecutter_args_with_branch(self):
-        args = main.parse_cookiecutter_args(['project/', '--checkout', 'develop'])
-        self.assertEqual(args.input_dir, 'project/')
-        self.assertEqual(args.checkout, 'develop')
-
-
 class TestAbbreviationExpansion(unittest.TestCase):
 
     def test_abbreviation_expansion(self):


### PR DESCRIPTION
Simply convert `TestArgParsing` of ` test_main.py` to `py.test` syntax. No magic involved whatsoever :see_no_evil: