### PR TITLE
Convert test cookiecutter repo arg to pytest

### DIFF
--- a/tests/skipif_markers.py
+++ b/tests/skipif_markers.py
@@ -30,7 +30,10 @@ else:
 # which condition matches. Using a unified message for now
 # travis_reason = 'Works locally with tox but fails on Travis.'
 # no_network_reason = 'Needs a network connection to GitHub.'
-reason = 'Fails on Travis or else there is no network connection to GitHub'
+reason = (
+    'Fails on Travis or else there is no network connection to '
+    'GitHub/Bitbucket.'
+)
 
 skipif_travis = pytest.mark.skipif(travis, reason=reason)
 skipif_no_network = pytest.mark.skipif(no_network, reason=reason)

--- a/tests/test_cookiecutter_repo_arg.py
+++ b/tests/test_cookiecutter_repo_arg.py
@@ -7,6 +7,7 @@ test_cookiecutter_repo_arg
 
 Tests formerly known from a unittest residing in test_main.py named
 TestCookiecutterRepoArg.test_cookiecutter_git
+TestCookiecutterRepoArg.test_cookiecutter_mercurial
 """
 
 from __future__ import unicode_literals
@@ -48,3 +49,19 @@ def test_cookiecutter_git(monkeypatch):
     assert os.path.isdir('boilerplate')
     assert os.path.isfile('boilerplate/README.rst')
     assert os.path.exists('boilerplate/setup.py')
+
+
+@skipif_no_network
+@pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
+def test_cookiecutter_mercurial(monkeypatch):
+    monkeypatch.setattr('cookiecutter.prompt.read_response', lambda x=u'': u'')
+
+    main.cookiecutter('https://bitbucket.org/pokoli/cookiecutter-trytonmodule')
+    clone_dir = os.path.join(
+        os.path.expanduser('~/.cookiecutters'),
+        'cookiecutter-trytonmodule'
+    )
+    assert os.path.exists(clone_dir)
+    assert os.path.isdir('module_name')
+    assert os.path.isfile('module_name/README')
+    assert os.path.exists('module_name/setup.py')

--- a/tests/test_cookiecutter_repo_arg.py
+++ b/tests/test_cookiecutter_repo_arg.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_cookiecutter_repo_arg
+--------------------------
+
+Tests formerly known from a unittest residing in test_main.py named
+TestCookiecutterRepoArg.test_cookiecutter_git
+"""
+
+from __future__ import unicode_literals
+import os
+import pytest
+
+from cookiecutter import main, utils
+from tests.skipif_markers import skipif_no_network
+
+
+@pytest.fixture(scope='function')
+def remove_additional_folders(request):
+    """
+    Remove some special folders which are created by the tests.
+    """
+    def fin_remove_additional_folders():
+        if os.path.isdir('cookiecutter-pypackage'):
+            utils.rmtree('cookiecutter-pypackage')
+        if os.path.isdir('boilerplate'):
+            utils.rmtree('boilerplate')
+        if os.path.isdir('cookiecutter-trytonmodule'):
+            utils.rmtree('cookiecutter-trytonmodule')
+        if os.path.isdir('module_name'):
+            utils.rmtree('module_name')
+    request.addfinalizer(fin_remove_additional_folders)
+
+
+@skipif_no_network
+@pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
+def test_cookiecutter_git(monkeypatch):
+    monkeypatch.setattr('cookiecutter.prompt.read_response', lambda x=u'': u'')
+
+    main.cookiecutter('https://github.com/audreyr/cookiecutter-pypackage.git')
+    clone_dir = os.path.join(
+        os.path.expanduser('~/.cookiecutters'),
+        'cookiecutter-pypackage'
+    )
+    assert os.path.exists(clone_dir)
+    assert os.path.isdir('boilerplate')
+    assert os.path.isfile('boilerplate/README.rst')
+    assert os.path.exists('boilerplate/setup.py')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -147,30 +147,5 @@ class TestAbbreviationExpansion(unittest.TestCase):
         )
 
 
-@unittest.skipIf(condition=no_network, reason='Needs a network connection to GitHub/Bitbucket.')
-class TestCookiecutterRepoArg(CookiecutterCleanSystemTestCase):
-
-    def tearDown(self):
-        if os.path.isdir('cookiecutter-pypackage'):
-            utils.rmtree('cookiecutter-pypackage')
-        if os.path.isdir('boilerplate'):
-            utils.rmtree('boilerplate')
-        if os.path.isdir('cookiecutter-trytonmodule'):
-            utils.rmtree('cookiecutter-trytonmodule')
-        if os.path.isdir('module_name'):
-            utils.rmtree('module_name')
-        super(TestCookiecutterRepoArg, self).tearDown()
-
-    @patch('cookiecutter.prompt.read_response', lambda x=u'': u'')
-    def test_cookiecutter_mercurial(self):
-        main.cookiecutter('https://bitbucket.org/pokoli/cookiecutter-trytonmodule')
-        logging.debug('Current dir is {0}'.format(os.getcwd()))
-        clone_dir = os.path.join(os.path.expanduser('~/.cookiecutters'), 'cookiecutter-trytonmodule')
-        self.assertTrue(os.path.exists(clone_dir))
-        self.assertTrue(os.path.isdir('module_name'))
-        self.assertTrue(os.path.isfile('module_name/README'))
-        self.assertTrue(os.path.exists('module_name/setup.py'))
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -162,16 +162,6 @@ class TestCookiecutterRepoArg(CookiecutterCleanSystemTestCase):
         super(TestCookiecutterRepoArg, self).tearDown()
 
     @patch('cookiecutter.prompt.read_response', lambda x=u'': u'')
-    def test_cookiecutter_git(self):
-        main.cookiecutter('https://github.com/audreyr/cookiecutter-pypackage.git')
-        logging.debug('Current dir is {0}'.format(os.getcwd()))
-        clone_dir = os.path.join(os.path.expanduser('~/.cookiecutters'), 'cookiecutter-pypackage')
-        self.assertTrue(os.path.exists(clone_dir))
-        self.assertTrue(os.path.isdir('boilerplate'))
-        self.assertTrue(os.path.isfile('boilerplate/README.rst'))
-        self.assertTrue(os.path.exists('boilerplate/setup.py'))
-
-    @patch('cookiecutter.prompt.read_response', lambda x=u'': u'')
     def test_cookiecutter_mercurial(self):
         main.cookiecutter('https://bitbucket.org/pokoli/cookiecutter-trytonmodule')
         logging.debug('Current dir is {0}'.format(os.getcwd()))


### PR DESCRIPTION
This `py.test` re-implementation of `test_main.TestCookiecutterRepoArg` features `setup/teardown` fixtures, `skipif` markers as well as `monkeypatch`. The test itself is pretty much straightforward.

Please let me know your thoughts. Cheers :smile: