### PR TITLE
Hackebrot convert test find

### DIFF
--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -9,14 +9,19 @@ Tests for `cookiecutter.find` module.
 """
 
 import os
+import pytest
 import shutil
 import unittest
 
 from cookiecutter import find
 
 
-def test_find_template():
-    repo_dir = os.path.join('tests', 'fake-repo-pre')
+@pytest.fixture(params=['fake-repo-pre', 'fake-repo-pre2'])
+def repo_dir(request):
+    return os.path.join('tests', request.param)
+
+
+def test_find_template(repo_dir):
     template = find.find_template(repo_dir=repo_dir)
 
     test_dir = os.path.join(repo_dir, '{{cookiecutter.repo_name}}')

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -16,15 +16,16 @@ from cookiecutter import find
 
 
 def test_find_template():
-    template = find.find_template(repo_dir='tests/fake-repo-pre'.replace("/", os.sep))
+    repo_dir = os.path.join('tests', 'fake-repo-pre')
+    template = find.find_template(repo_dir=repo_dir)
 
-    test_dir = 'tests/fake-repo-pre/{{cookiecutter.repo_name}}'.replace("/", os.sep)
+    test_dir = os.path.join(repo_dir, '{{cookiecutter.repo_name}}')
     assert template == test_dir
 
-    test_dir = 'tests/fake-repo-pre/{{cookiecutter.repo_name }}'.replace("/", os.sep)
+    test_dir = os.path.join(repo_dir, '{{cookiecutter.repo_name }}')
     assert template != test_dir
 
-    test_dir = 'tests/fake-repo-pre/{{ cookiecutter.repo_name }}'.replace("/", os.sep)
+    test_dir = os.path.join(repo_dir, '{{ cookiecutter.repo_name }}')
     assert template != test_dir
 
 

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -3,15 +3,13 @@
 
 """
 test_find
-------------
+---------
 
 Tests for `cookiecutter.find` module.
 """
 
 import os
 import pytest
-import shutil
-import unittest
 
 from cookiecutter import find
 
@@ -32,19 +30,3 @@ def test_find_template(repo_dir):
 
     test_dir = os.path.join(repo_dir, '{{ cookiecutter.repo_name }}')
     assert template != test_dir
-
-
-class TestFindTemplate2(unittest.TestCase):
-
-    def test_find_template(self):
-        template = find.find_template(repo_dir='tests/fake-repo-pre2'.replace("/", os.sep))
-        test_dir = 'tests/fake-repo-pre2/{{cookiecutter.repo_name}}'.replace("/", os.sep)
-        self.assertEqual(template, test_dir)
-        test_dir = 'tests/fake-repo-pre2/{{cookiecutter.repo_name }}'.replace("/", os.sep)
-        self.assertNotEqual(template, test_dir)
-        test_dir = 'tests/fake-repo-pre2/{{ cookiecutter.repo_name }}'.replace("/", os.sep)
-        self.assertNotEqual(template, test_dir)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -15,16 +15,17 @@ import unittest
 from cookiecutter import find
 
 
-class TestFindTemplate(unittest.TestCase):
+def test_find_template():
+    template = find.find_template(repo_dir='tests/fake-repo-pre'.replace("/", os.sep))
 
-    def test_find_template(self):
-        template = find.find_template(repo_dir='tests/fake-repo-pre'.replace("/", os.sep))
-        test_dir = 'tests/fake-repo-pre/{{cookiecutter.repo_name}}'.replace("/", os.sep)
-        self.assertEqual(template, test_dir)
-        test_dir = 'tests/fake-repo-pre/{{cookiecutter.repo_name }}'.replace("/", os.sep)
-        self.assertNotEqual(template, test_dir)
-        test_dir = 'tests/fake-repo-pre/{{ cookiecutter.repo_name }}'.replace("/", os.sep)
-        self.assertNotEqual(template, test_dir)
+    test_dir = 'tests/fake-repo-pre/{{cookiecutter.repo_name}}'.replace("/", os.sep)
+    assert template == test_dir
+
+    test_dir = 'tests/fake-repo-pre/{{cookiecutter.repo_name }}'.replace("/", os.sep)
+    assert template != test_dir
+
+    test_dir = 'tests/fake-repo-pre/{{ cookiecutter.repo_name }}'.replace("/", os.sep)
+    assert template != test_dir
 
 
 class TestFindTemplate2(unittest.TestCase):

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -24,9 +24,3 @@ def test_find_template(repo_dir):
 
     test_dir = os.path.join(repo_dir, '{{cookiecutter.repo_name}}')
     assert template == test_dir
-
-    test_dir = os.path.join(repo_dir, '{{cookiecutter.repo_name }}')
-    assert template != test_dir
-
-    test_dir = os.path.join(repo_dir, '{{ cookiecutter.repo_name }}')
-    assert template != test_dir


### PR DESCRIPTION
Convert `test_find.TestFindTemplate` and `test_main.TestFindTemplate2` to `py.test`.

Please give your attention to 0208a38 as I removed some asserts which seem to be redundant. Since we are testing for equality first (`assert template == 'foo'`), I don't see any way how a subsequent test for inequality should fail (`assert template != 'bar'`) without changing `template`.

Let me know your thoughts!