### PR TITLE
Hackebrot integrate pytest in setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,14 +27,14 @@ lint:
 	flake8 cookiecutter tests
 
 test:
-	py.test
+	python setup.py test
 
 test-all:
 	tox
 
 
 coverage:
-	coverage run --source cookiecutter -m py.test
+	coverage run --source cookiecutter setup.py test
 	coverage report -m
 	coverage html
 	open htmlcov/index.html

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = --cov cookiecutter --cov-report term-missing tests

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,7 @@ class PyTest(Command):
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
 
     def initialize_options(self):
-        self.pytest_args = [
-            'tests',
-            '--cov', 'cookiecutter',
-            '--cov-report', 'term-missing'
-        ]
+        self.pytest_args = []
 
     def finalize_options(self):
         pass

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ import os
 import sys
 
 try:
-    from setuptools import setup
+    from setuptools import setup, Command
 except ImportError:
-    from distutils.core import setup
+    from distutils.core import setup, Command
 
 if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
@@ -16,7 +16,7 @@ readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 requirements = ['binaryornot>=0.2.0', 'jinja2>=2.4', 'PyYAML>=3.10']
-test_requirements = []
+test_requirements = ['pytest']
 
 # Add Python 2.6-specific dependencies
 if sys.version_info[:2] < (2, 7):
@@ -30,6 +30,26 @@ if sys.version < '3':
     requirements.append('mock')
 
 # There are no Python 3-specific dependencies to add
+
+
+class PyTest(Command):
+    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
+
+    def initialize_options(self):
+        self.pytest_args = [
+            'tests',
+            '--cov', 'cookiecutter',
+            '--cov-report', 'term-missing'
+        ]
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        import pytest
+        errno = pytest.main(self.pytest_args)
+        sys.exit(errno)
+
 
 setup(
     name='cookiecutter',
@@ -73,6 +93,7 @@ setup(
     ],
     keywords='cookiecutter, Python, projects, project templates, Jinja2, \
         skeleton, scaffolding, project directory, setup.py, package, packaging',
+    cmdclass = {'test': PyTest},
     test_suite='tests',
     tests_require=test_requirements
 )


### PR DESCRIPTION
I implemented a `PyTest` command class in `setup.py` similar to http://pytest.org/latest/goodpractises.html#integration-with-setuptools-test-commands

Currently `python setup.py test` still uses `unittest` which means some of the re-implementations are not run at all. By changing this the documentation changes to `CONTRIBUTING.rst` of #310 are correct again.

Additionally I removed `pytest.ini` to address #333. It stopped us from running only specific tests as for instance `py.test tests/test_generate_file.py`. More importantly the suite is not executed twice any longer and the coverage is not calculated when running tests only.

Your feedback is highly appreciated! :kissing_closed_eyes: