### PR TITLE
Jinja2>=2.7 is actually needed.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if sys.argv[-1] == 'publish':
 readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
-requirements = ['binaryornot>=0.2.0', 'jinja2>=2.4', 'PyYAML>=3.10']
+requirements = ['binaryornot>=0.2.0', 'jinja2>=2.7', 'PyYAML>=3.10']
 test_requirements = []
 
 # Add Python 2.6-specific dependencies


### PR DESCRIPTION
With jinja2<2.7, cookiecutter fails with error:

  File "/usr/local/lib/python2.7/site-packages/cookiecutter/generate.py", line 181, in generate_files
    env = Environment(keep_trailing_newline=True)
TypeError: __init__() got an unexpected keyword argument 'keep_trailing_newline'

