### PR TITLE
Support yaml context files

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -20,7 +20,7 @@ import sys
 from . import __version__
 from .config import get_user_config
 from .prompt import prompt_for_config
-from .generate import generate_context, generate_files
+from .generate import generate_context, generate_files, get_context_file
 from .vcs import clone
 
 logger = logging.getLogger(__name__)
@@ -86,11 +86,8 @@ def cookiecutter(input_dir, checkout=None, no_input=False, extra_context=None):
         # cookiecutters_dir
         repo_dir = input_dir
 
-    context_file = os.path.join(repo_dir, 'cookiecutter.json')
-    logging.debug('context_file is {0}'.format(context_file))
-
     context = generate_context(
-        context_file=context_file,
+        get_context_file(repo_dir=repo_dir),
         default_context=config_dict['default_context'],
         extra_context=extra_context,
     )

--- a/tests/test-generate-context/test.yaml
+++ b/tests/test-generate-context/test.yaml
@@ -1,0 +1,2 @@
+1: 2
+some_key: some_val

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -16,6 +16,7 @@ from __future__ import unicode_literals
 import pytest
 
 from cookiecutter import generate
+from cookiecutter.compat import OrderedDict
 
 
 def context_data():
@@ -59,10 +60,20 @@ def context_data():
         }
     )
 
+    context_from_yaml = (
+        {
+            'context_file': 'tests/test-generate-context/test.yaml',
+        },
+        {
+            'test': OrderedDict([(1, 2), ('some_key', 'some_val')])
+        }
+    )
+
     yield context
     yield context_with_default
     yield context_with_extra
     yield context_with_default_and_extra
+    yield context_from_yaml
 
 
 @pytest.mark.usefixtures('clean_system')


### PR DESCRIPTION
Related to #249

I tried to use #269 but it's diverged quite a bit from master. I resolved the conflicts and started trying to get it working again, but it ended up being a lot more work than just starting from scratch.

This was the smallest change I found that allowed me to read yaml context files, and still maintain backwards compatibility with the json files.

Feedback welcome.
