### PR TITLE
Support better prompts

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -60,20 +60,19 @@ def prompt_for_config(context, no_input=False):
 
     for key, raw in iteritems(context['cookiecutter']):
         context_entry = get_context_entry(key, raw)
-        value = (env.from_string(context_entry.default)
-                    .render(cookiecutter=cookiecutter_dict))
+        default = (env.from_string(context_entry.default)
+                   .render(cookiecutter=cookiecutter_dict))
 
         if not no_input:
             prompt = '{entry.prompt} (default is "{default}")? '.format(
                 entry=context_entry,
-                default=value)
+                default=default)
 
-            value = get_value(
-                context_entry,
-                read_response(prompt).strip(),
-                value)
+            value = read_response(prompt).strip()
+        else:
+            value = ''
 
-        cookiecutter_dict[key] = value
+        cookiecutter_dict[key] = get_value(context_entry, value, default)
     return cookiecutter_dict
 
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -64,6 +64,37 @@ class TestPrompt(unittest.TestCase):
         self.assertEqual(cookiecutter_dict, {"project_name": u"A New Project",
              "pkg_name": u"anewproject"})
 
+    @patch('cookiecutter.prompt.read_response', lambda x=u'': u'\n')
+    def test_prompt_for_config_with_dict_context_entry(self):
+        context = {'cookiecutter': OrderedDict([
+            (
+                'project_name', {
+                    'default': u'A New Project',
+                    'prompt': u'Your project name',
+                },
+            ),
+            (
+                'include_extras', {
+                    'default': u'no',
+                    'prompt':  u'Include extra things?',
+                    'type': 'boolean',
+                },
+            ),
+            (
+                 'include_tests', {
+                    'default': u'yes',
+                    'prompt':  u'Include some test files?',
+                    'type': 'boolean',
+                },
+            ),
+        ])}
+        context = prompt.prompt_for_config(context)
+        self.assertEqual(context, {
+            'project_name': u'A New Project',
+            'include_extras': False,
+            'include_tests': True,
+        })
+
 
 class TestQueryAnswers(unittest.TestCase):
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -96,6 +96,27 @@ class TestPrompt(unittest.TestCase):
         })
 
 
+class TestPromptNoInput(unittest.TestCase):
+
+    def test_prompt_no_input(self):
+        orig_context = {"cookiecutter": {"project_name": u"A New Project"}}
+        context = prompt.prompt_for_config(orig_context, no_input=True)
+        self.assertEqual(context, orig_context['cookiecutter'])
+
+    def test_prompt_no_input_with_rich_context_type(self):
+        context = {'cookiecutter': OrderedDict([
+            (
+                 'include_tests', {
+                    'default': u'yes',
+                    'prompt':  u'Include some test files?',
+                    'type': 'boolean',
+                },
+            ),
+        ])}
+        context = prompt.prompt_for_config(context, no_input=True)
+        self.assertEqual(context, {'include_tests': True})
+
+
 class TestQueryAnswers(unittest.TestCase):
 
     @patch('cookiecutter.prompt.read_response', lambda x=u'': u'y')


### PR DESCRIPTION
Resolves #30 

This change maintains backwards compatibility with the old format, so a context version isn't really necessary (although it wouldn't hurt if the context supported it).

Currently only supports one `type` of boolean, so that context parameters can be used in `if` blocks. Without this support you can't really have a default of `True`, and have the user enter `False` (because any value the user enters would be `True`.  I suspect there will  be other types that can be added here.
