### PR TITLE
Fix the broken roadmap link in HISTORY.rst

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -382,5 +382,5 @@ Bumped to "Development Status :: 3 - Alpha".
 Roadmap
 -------
 
-https://github.com/audreyr/cookiecutter/issues/milestones
+https://github.com/audreyr/cookiecutter/milestones?direction=desc&sort=due_date&state=open
 


### PR DESCRIPTION
I get the current roadmap link from the [CONTRIBUTING.rst](https://github.com/audreyr/cookiecutter/blob/master/CONTRIBUTING.rst#process-roadmap)