### PR TITLE
Add cookiecutter-latex-article to list of LaTeX templates.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -200,6 +200,7 @@ LaTeX/XeTeX
 ~~~~~~~~~~~
 
 * `pandoc-talk`_: A cookiecutter template for giving talks with pandoc and XeTeX.
+* `cookiecutter-latex-article`_: A LaTeX template geared towards academic use.
 
 
 Berkshelf-Vagrant
@@ -238,6 +239,7 @@ HTML
 .. _`docopt`: http://docopt.org/
 .. _`cookiecutter-jswidget`: https://github.com/audreyr/cookiecutter-jswidget
 .. _`pandoc-talk`: https://github.com/larsyencken/pandoc-talk
+.. _`cookiecutter-latex-article`: https://github.com/Kreger51/cookiecutter-latex-article
 .. _`cookiecutter-complexity`: https://github.com/audreyr/cookiecutter-complexity
 .. _`cookiecutter-cl-project`: https://github.com/svetlyak40wt/cookiecutter-cl-project
 .. _`slim-berkshelf-vagrant`: https://github.com/mahmoudimus/cookiecutter-slim-berkshelf-vagrant


### PR DESCRIPTION
Hi!

I would be pleased if you would add my template to the list.

I'm currently a student and use this template to write my lab reports/essays and basically anything that I don't do by hand. However, it could be used for anything that makes use of the ``article`` document class. 

The template can be found at: https://github.com/Kreger51/cookiecutter-latex-article. 

Appreciate the utility by the way!

Thanks, 

Selim
 