### PR TITLE
README.rst: Fix AppVeyor badge link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Cookiecutter
         :target: https://travis-ci.org/audreyr/cookiecutter
 
 .. image:: https://ci.appveyor.com/api/projects/status/github/audreyr/cookiecutter?branch=master
-        :target: https://ci.appveyor.com/api/projects/status/github/audreyr/cookiecutter?branch=master
+        :target: https://ci.appveyor.com/project/audreyr/cookiecutter/branch/master
 
 .. image:: https://pypip.in/d/cookiecutter/badge.png
         :target: https://crate.io/packages/cookiecutter?version=latest


### PR DESCRIPTION
Clicking it was taking me to the badge image instead of the actual builds.

Compare clicking the badge at https://github.com/audreyr/cookiecutter/blob/master/README.rst vs. https://github.com/msabramo/cookiecutter/blob/fix_appveyor_badge_link/README.rst