### PR TITLE
tox.ini: Fix flake8 version conflict

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
 
 [testenv:flake8]
 deps =
-    flake8
+    flake8==2.3.0
     pep8==1.6.2
 commands =
     flake8 cookiecutter


### PR DESCRIPTION
Fixes the following version conflict error:

    $ rm -rf .tox/flake8
    $ tox -e flake8
    ...
      File "/Users/marca/dev/git-repos/cookiecutter/.tox/flake8/lib/python2.7/site-packages/pkg_resources.py", line 643, in resolve
        raise VersionConflict(dist, req) # XXX put more info here
    pkg_resources.VersionConflict: (pep8 1.6.2 (/Users/marca/dev/git-repos/cookiecutter/.tox/flake8/lib/python2.7/site-packages), Requirement.parse('pep8>=1.5.7,<1.6'))
    ...