### PR TITLE
pytest.ini: Remove `tests` from addopts

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --cov cookiecutter --cov-report term-missing tests
+addopts = --cov cookiecutter --cov-report term-missing


### PR DESCRIPTION
Otherwise, it will always run all tests even if you the user gives arguments to `py.test`. In fact, it will run the specified tests twice.

This and #335 fix #333.