### PR TITLE
Convert test utils to pytest

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,6 +17,9 @@ from cookiecutter import utils
 
 
 def make_readonly(path):
+    """Helper function that is called in the tests to change the access
+    permissions of the given file.
+    """
     mode = os.stat(path).st_mode
     os.chmod(path, mode & ~stat.S_IWRITE)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ import os
 import sys
 import stat
 import unittest
+import pytest
 
 from cookiecutter import utils
 
@@ -49,26 +50,26 @@ def test_make_sure_path_exists():
     utils.rmtree('tests/blah/')
     utils.rmtree('tests/trailingslash/')
 
-class TestUtils(unittest.TestCase):
 
-    def test_workin(self):
-        cwd = os.getcwd()
-        ch_to = 'tests/files'
+def test_workin():
+    cwd = os.getcwd()
+    ch_to = 'tests/files'
 
-        class TestException(Exception):
-            pass
+    class TestException(Exception):
+        pass
 
-        def test_work_in():
-            with utils.work_in(ch_to):
-                test_dir = os.path.join(cwd, ch_to).replace("/", os.sep)
-                self.assertEqual(test_dir, os.getcwd())
-                raise TestException()
+    def test_work_in():
+        with utils.work_in(ch_to):
+            test_dir = os.path.join(cwd, ch_to).replace("/", os.sep)
+            assert test_dir == os.getcwd()
+            raise TestException()
 
-        # Make sure we return to the correct folder
-        self.assertEqual(cwd, os.getcwd())
+    # Make sure we return to the correct folder
+    assert cwd == os.getcwd()
 
-        # Make sure that exceptions are still bubbled up
-        self.assertRaises(TestException, test_work_in)
+    # Make sure that exceptions are still bubbled up
+    with pytest.raises(TestException):
+        test_work_in()
 
 
 if __name__ == '__main__':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,22 +33,23 @@ def test_rmtree():
     utils.rmtree('foo')
     assert not os.path.exists('foo')
 
+
+def test_make_sure_path_exists():
+    if sys.platform.startswith('win'):
+        existing_directory = os.path.abspath(os.curdir)
+        uncreatable_directory = 'a*b'
+    else:
+        existing_directory = '/usr/'
+        uncreatable_directory = '/this-doesnt-exist-and-cant-be-created/'
+
+    assert utils.make_sure_path_exists(existing_directory)
+    assert utils.make_sure_path_exists('tests/blah')
+    assert utils.make_sure_path_exists('tests/trailingslash/')
+    assert not utils.make_sure_path_exists(uncreatable_directory)
+    utils.rmtree('tests/blah/')
+    utils.rmtree('tests/trailingslash/')
+
 class TestUtils(unittest.TestCase):
-
-    def test_make_sure_path_exists(self):
-        if sys.platform.startswith('win'):
-            existing_directory = os.path.abspath(os.curdir)
-            uncreatable_directory = 'a*b'
-        else:
-            existing_directory = '/usr/'
-            uncreatable_directory = '/this-doesnt-exist-and-cant-be-created/'
-
-        self.assertTrue(utils.make_sure_path_exists(existing_directory))
-        self.assertTrue(utils.make_sure_path_exists('tests/blah'))
-        self.assertTrue(utils.make_sure_path_exists('tests/trailingslash/'))
-        self.assertFalse(utils.make_sure_path_exists(uncreatable_directory))
-        utils.rmtree('tests/blah/')
-        utils.rmtree('tests/trailingslash/')
 
     def test_workin(self):
         cwd = os.getcwd()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,10 +9,9 @@ Tests for `cookiecutter.utils` module.
 """
 
 import os
-import sys
-import stat
-import unittest
 import pytest
+import stat
+import sys
 
 from cookiecutter import utils
 
@@ -23,7 +22,6 @@ def make_readonly(path):
     """
     mode = os.stat(path).st_mode
     os.chmod(path, mode & ~stat.S_IWRITE)
-
 
 
 def test_rmtree():
@@ -70,7 +68,3 @@ def test_workin():
     # Make sure that exceptions are still bubbled up
     with pytest.raises(TestException):
         test_work_in()
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,15 +24,16 @@ def make_readonly(path):
     os.chmod(path, mode & ~stat.S_IWRITE)
 
 
-class TestUtils(unittest.TestCase):
 
-    def test_rmtree(self):
-        os.mkdir('foo')
-        with open('foo/bar', "w") as f:
-            f.write("Test data")
-        make_readonly('foo/bar')
-        utils.rmtree('foo')
-        self.assertFalse(os.path.exists('foo'))
+def test_rmtree():
+    os.mkdir('foo')
+    with open('foo/bar', "w") as f:
+        f.write("Test data")
+    make_readonly('foo/bar')
+    utils.rmtree('foo')
+    assert not os.path.exists('foo')
+
+class TestUtils(unittest.TestCase):
 
     def test_make_sure_path_exists(self):
         if sys.platform.startswith('win'):


### PR DESCRIPTION
Convert `test_utils.py` to `py.test` syntax.

Apart from using `pytest.raises` this PR only changes the class `unittest` methods to module functions as no setup or teardown code is necessary whatsoever.