### PR TITLE
Convert test vcs to pytest

### DIFF
--- a/tests/test_identify_repo.py
+++ b/tests/test_identify_repo.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 """
-test_identify_repo.py
----------------------
+test_identify_repo
+------------------
 """
 
 import pytest

--- a/tests/test_identify_repo.py
+++ b/tests/test_identify_repo.py
@@ -12,28 +12,28 @@ from cookiecutter import exceptions, vcs
 
 
 def test_identify_git_github():
-    repo_url = "https://github.com/audreyr/cookiecutter-pypackage.git"
-    assert vcs.identify_repo(repo_url) == "git"
+    repo_url = 'https://github.com/audreyr/cookiecutter-pypackage.git'
+    assert vcs.identify_repo(repo_url) == 'git'
 
 
 def test_identify_git_github_no_extension():
-    repo_url = "https://github.com/audreyr/cookiecutter-pypackage"
-    assert vcs.identify_repo(repo_url) == "git"
+    repo_url = 'https://github.com/audreyr/cookiecutter-pypackage'
+    assert vcs.identify_repo(repo_url) == 'git'
 
 
 def test_identify_git_gitorious():
     repo_url = (
-        "git@gitorious.org:cookiecutter-gitorious/cookiecutter-gitorious.git"
+        'git@gitorious.org:cookiecutter-gitorious/cookiecutter-gitorious.git'
     )
-    assert vcs.identify_repo(repo_url) == "git"
+    assert vcs.identify_repo(repo_url) == 'git'
 
 
 def test_identify_hg_mercurial():
-    repo_url = "https://audreyr@bitbucket.org/audreyr/cookiecutter-bitbucket"
-    assert vcs.identify_repo(repo_url) == "hg"
+    repo_url = 'https://audreyr@bitbucket.org/audreyr/cookiecutter-bitbucket'
+    assert vcs.identify_repo(repo_url) == 'hg'
 
 
 def test_unknown_repo_type():
-    repo_url = "http://norepotypespecified.com"
+    repo_url = 'http://norepotypespecified.com'
     with pytest.raises(exceptions.UnknownRepoType):
         vcs.identify_repo(repo_url)

--- a/tests/test_identify_repo.py
+++ b/tests/test_identify_repo.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_identify_repo.py
+---------------------
+"""
+
+import pytest
+
+from cookiecutter import exceptions, vcs
+
+
+def test_identify_git_github():
+    repo_url = "https://github.com/audreyr/cookiecutter-pypackage.git"
+    assert vcs.identify_repo(repo_url) == "git"
+
+
+def test_identify_git_github_no_extension():
+    repo_url = "https://github.com/audreyr/cookiecutter-pypackage"
+    assert vcs.identify_repo(repo_url) == "git"
+
+
+def test_identify_git_gitorious():
+    repo_url = (
+        "git@gitorious.org:cookiecutter-gitorious/cookiecutter-gitorious.git"
+    )
+    assert vcs.identify_repo(repo_url) == "git"
+
+
+def test_identify_hg_mercurial():
+    repo_url = "https://audreyr@bitbucket.org/audreyr/cookiecutter-bitbucket"
+    assert vcs.identify_repo(repo_url) == "hg"
+
+
+def test_unknown_repo_type():
+    repo_url = "http://norepotypespecified.com"
+    with pytest.raises(exceptions.UnknownRepoType):
+        vcs.identify_repo(repo_url)

--- a/tests/test_is_vcs_installed.py
+++ b/tests/test_is_vcs_installed.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_is_vcs_installed
+---------------------
+"""
+
+from cookiecutter import vcs
+
+
+def test_existing_repo_type():
+    assert vcs.is_vcs_installed("git")
+
+
+def test_non_existing_repo_type():
+    assert not vcs.is_vcs_installed("stringthatisntashellcommand")

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -38,29 +38,31 @@ def test_git_clone():
         utils.rmtree('cookiecutter-pypackage')
 
 
+@skipif_no_network
+def test_git_clone_checkout():
+    repo_dir = vcs.clone(
+        'https://github.com/audreyr/cookiecutter-pypackage.git',
+        'console-script'
+    )
+    git_dir = 'cookiecutter-pypackage'
+    assert repo_dir == git_dir
+    assert os.path.isfile(os.path.join('cookiecutter-pypackage', 'README.rst'))
+
+    proc = subprocess.Popen(
+        ['git', 'symbolic-ref', 'HEAD'],
+        cwd=git_dir,
+        stdout=subprocess.PIPE
+    )
+    symbolic_ref = proc.communicate()[0]
+    branch = symbolic_ref.decode(encoding).strip().split('/')[-1]
+    assert 'console-script' == branch
+
+    if os.path.isdir(git_dir):
+        utils.rmtree(git_dir)
+
+
 @unittest.skipIf(condition=no_network, reason='Needs a network connection to GitHub/Bitbucket.')
 class TestVCS(unittest.TestCase):
-
-    def test_git_clone_checkout(self):
-        repo_dir = vcs.clone(
-            'https://github.com/audreyr/cookiecutter-pypackage.git',
-            'console-script'
-        )
-        git_dir = 'cookiecutter-pypackage'
-        self.assertEqual(repo_dir, git_dir)
-        self.assertTrue(os.path.isfile(os.path.join('cookiecutter-pypackage', 'README.rst')))
-
-        proc = subprocess.Popen(
-            ['git', 'symbolic-ref', 'HEAD'],
-            cwd=git_dir,
-            stdout=subprocess.PIPE
-        )
-        symbolic_ref = proc.communicate()[0]
-        branch = symbolic_ref.decode(encoding).strip().split('/')[-1]
-        self.assertEqual('console-script', branch)
-
-        if os.path.isdir(git_dir):
-            utils.rmtree(git_dir)
 
     def test_git_clone_custom_dir(self):
         os.makedirs("tests/custom_dir1/custom_dir2/")

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -11,6 +11,7 @@ Tests for `cookiecutter.vcs` module.
 import locale
 import logging
 import os
+import pytest
 import subprocess
 import unittest
 
@@ -28,31 +29,31 @@ logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 encoding = locale.getdefaultlocale()[1]
 
 
-class TestIdentifyRepo(unittest.TestCase):
 
-    def test_identify_git_github(self):
-        repo_url = "https://github.com/audreyr/cookiecutter-pypackage.git"
-        self.assertEqual(vcs.identify_repo(repo_url), "git")
+def test_identify_git_github():
+    repo_url = "https://github.com/audreyr/cookiecutter-pypackage.git"
+    assert vcs.identify_repo(repo_url) == "git"
 
-    def test_identify_git_github_no_extension(self):
-        repo_url = "https://github.com/audreyr/cookiecutter-pypackage"
-        self.assertEqual(vcs.identify_repo(repo_url), "git")
 
-    def test_identify_git_gitorious(self):
-        repo_url = "git@gitorious.org:cookiecutter-gitorious/cookiecutter-gitorious.git"
-        self.assertEqual(vcs.identify_repo(repo_url), "git")
+def test_identify_git_github_no_extension():
+    repo_url = "https://github.com/audreyr/cookiecutter-pypackage"
+    assert vcs.identify_repo(repo_url) == "git"
 
-    def test_identify_hg_mercurial(self):
-        repo_url = "https://audreyr@bitbucket.org/audreyr/cookiecutter-bitbucket"
-        self.assertEqual(vcs.identify_repo(repo_url), "hg")
 
-    def test_unknown_repo_type(self):
-        repo_url = "http://norepotypespecified.com"
-        self.assertRaises(
-            exceptions.UnknownRepoType,
-            vcs.identify_repo,
-            repo_url
-        )
+def test_identify_git_gitorious():
+    repo_url = "git@gitorious.org:cookiecutter-gitorious/cookiecutter-gitorious.git"
+    assert vcs.identify_repo(repo_url) == "git"
+
+
+def test_identify_hg_mercurial():
+    repo_url = "https://audreyr@bitbucket.org/audreyr/cookiecutter-bitbucket"
+    assert vcs.identify_repo(repo_url) == "hg"
+
+
+def test_unknown_repo_type():
+    repo_url = "http://norepotypespecified.com"
+    with pytest.raises(exceptions.UnknownRepoType):
+        vcs.identify_repo(repo_url)
 
 
 @unittest.skipIf(condition=no_network, reason='Needs a network connection to GitHub/Bitbucket.')

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -12,16 +12,9 @@ import locale
 import os
 import pytest
 import subprocess
-import unittest
 
 from cookiecutter import exceptions, utils, vcs
 from tests.skipif_markers import skipif_no_network
-
-try:
-    no_network = os.environ[u'DISABLE_NETWORK_TESTS']
-except KeyError:
-    no_network = False
-
 
 encoding = locale.getdefaultlocale()[1]
 
@@ -99,7 +92,3 @@ def test_vcs_not_installed(monkeypatch):
     )
     with pytest.raises(exceptions.VCSNotInstalled):
         vcs.clone("http://norepotypespecified.com")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -95,31 +95,5 @@ class TestVCS(unittest.TestCase):
         )
 
 
-@unittest.skipIf(condition=no_network, reason='Needs a network connection to GitHub/Bitbucket.')
-class TestVCSPrompt(unittest.TestCase):
-
-    def setUp(self):
-        if os.path.isdir('cookiecutter-pypackage'):
-            utils.rmtree('cookiecutter-pypackage')
-        os.mkdir('cookiecutter-pypackage/')
-        if os.path.isdir('cookiecutter-trytonmodule'):
-            utils.rmtree('cookiecutter-trytonmodule')
-        os.mkdir('cookiecutter-trytonmodule/')
-
-    @patch('cookiecutter.prompt.read_response', lambda x=u'': u'n')
-    def test_hg_clone_cancel(self):
-        self.assertRaises(
-            SystemExit,
-            vcs.clone,
-            'https://bitbucket.org/pokoli/cookiecutter-trytonmodule'
-        )
-
-    def tearDown(self):
-        if os.path.isdir('cookiecutter-pypackage'):
-            utils.rmtree('cookiecutter-pypackage')
-        if os.path.isdir('cookiecutter-trytonmodule'):
-            utils.rmtree('cookiecutter-trytonmodule')
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -9,7 +9,6 @@ Tests for `cookiecutter.vcs` module.
 """
 
 import locale
-import logging
 import os
 import subprocess
 import unittest
@@ -23,8 +22,6 @@ except KeyError:
     no_network = False
 
 
-# Log debug and above to console
-logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 encoding = locale.getdefaultlocale()[1]
 
 

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -106,14 +106,6 @@ class TestVCSPrompt(unittest.TestCase):
             utils.rmtree('cookiecutter-trytonmodule')
         os.mkdir('cookiecutter-trytonmodule/')
 
-    @patch('cookiecutter.prompt.read_response', lambda x=u'': u'n')
-    def test_git_clone_cancel(self):
-        self.assertRaises(
-            SystemExit,
-            vcs.clone,
-            'https://github.com/audreyr/cookiecutter-pypackage.git'
-        )
-
     @patch('cookiecutter.prompt.read_response', lambda x=u'': u'y')
     def test_hg_clone_overwrite(self):
         repo_dir = vcs.clone(

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -15,6 +15,7 @@ import unittest
 
 from cookiecutter.compat import patch
 from cookiecutter import exceptions, utils, vcs
+from tests.skipif_markers import skipif_no_network
 
 try:
     no_network = os.environ[u'DISABLE_NETWORK_TESTS']
@@ -24,18 +25,21 @@ except KeyError:
 
 encoding = locale.getdefaultlocale()[1]
 
+@skipif_no_network
+def test_git_clone():
+    repo_dir = vcs.clone(
+        'https://github.com/audreyr/cookiecutter-pypackage.git'
+    )
+
+    assert repo_dir == 'cookiecutter-pypackage'
+    assert os.path.isfile('cookiecutter-pypackage/README.rst')
+
+    if os.path.isdir('cookiecutter-pypackage'):
+        utils.rmtree('cookiecutter-pypackage')
+
 
 @unittest.skipIf(condition=no_network, reason='Needs a network connection to GitHub/Bitbucket.')
 class TestVCS(unittest.TestCase):
-
-    def test_git_clone(self):
-        repo_dir = vcs.clone(
-            'https://github.com/audreyr/cookiecutter-pypackage.git'
-        )
-        self.assertEqual(repo_dir, 'cookiecutter-pypackage')
-        self.assertTrue(os.path.isfile('cookiecutter-pypackage/README.rst'))
-        if os.path.isdir('cookiecutter-pypackage'):
-            utils.rmtree('cookiecutter-pypackage')
 
     def test_git_clone_checkout(self):
         repo_dir = vcs.clone(

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -11,7 +11,6 @@ Tests for `cookiecutter.vcs` module.
 import locale
 import logging
 import os
-import pytest
 import subprocess
 import unittest
 
@@ -27,34 +26,6 @@ except KeyError:
 # Log debug and above to console
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 encoding = locale.getdefaultlocale()[1]
-
-
-def test_identify_git_github():
-    repo_url = "https://github.com/audreyr/cookiecutter-pypackage.git"
-    assert vcs.identify_repo(repo_url) == "git"
-
-
-def test_identify_git_github_no_extension():
-    repo_url = "https://github.com/audreyr/cookiecutter-pypackage"
-    assert vcs.identify_repo(repo_url) == "git"
-
-
-def test_identify_git_gitorious():
-    repo_url = (
-        "git@gitorious.org:cookiecutter-gitorious/cookiecutter-gitorious.git"
-    )
-    assert vcs.identify_repo(repo_url) == "git"
-
-
-def test_identify_hg_mercurial():
-    repo_url = "https://audreyr@bitbucket.org/audreyr/cookiecutter-bitbucket"
-    assert vcs.identify_repo(repo_url) == "hg"
-
-
-def test_unknown_repo_type():
-    repo_url = "http://norepotypespecified.com"
-    with pytest.raises(exceptions.UnknownRepoType):
-        vcs.identify_repo(repo_url)
 
 
 @unittest.skipIf(condition=no_network, reason='Needs a network connection to GitHub/Bitbucket.')

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -61,24 +61,26 @@ def test_git_clone_checkout():
         utils.rmtree(git_dir)
 
 
+@skipif_no_network
+def test_git_clone_custom_dir():
+    os.makedirs("tests/custom_dir1/custom_dir2/")
+    repo_dir = vcs.clone(
+        repo_url='https://github.com/audreyr/cookiecutter-pypackage.git',
+        checkout=None,
+        clone_to_dir="tests/custom_dir1/custom_dir2/"
+    )
+    with utils.work_in("tests/custom_dir1/custom_dir2/"):
+        test_dir = 'tests/custom_dir1/custom_dir2/cookiecutter-pypackage'
+        assert repo_dir == test_dir.replace("/", os.sep)
+        assert os.path.isfile('cookiecutter-pypackage/README.rst')
+        if os.path.isdir('cookiecutter-pypackage'):
+            utils.rmtree('cookiecutter-pypackage')
+    if os.path.isdir('tests/custom_dir1'):
+        utils.rmtree('tests/custom_dir1')
+
+
 @unittest.skipIf(condition=no_network, reason='Needs a network connection to GitHub/Bitbucket.')
 class TestVCS(unittest.TestCase):
-
-    def test_git_clone_custom_dir(self):
-        os.makedirs("tests/custom_dir1/custom_dir2/")
-        repo_dir = vcs.clone(
-            repo_url='https://github.com/audreyr/cookiecutter-pypackage.git',
-            checkout=None,
-            clone_to_dir="tests/custom_dir1/custom_dir2/"
-        )
-        with utils.work_in("tests/custom_dir1/custom_dir2/"):
-            test_dir = 'tests/custom_dir1/custom_dir2/cookiecutter-pypackage'.replace("/", os.sep)
-            self.assertEqual(repo_dir, test_dir)
-            self.assertTrue(os.path.isfile('cookiecutter-pypackage/README.rst'))
-            if os.path.isdir('cookiecutter-pypackage'):
-                utils.rmtree('cookiecutter-pypackage')
-        if os.path.isdir('tests/custom_dir1'):
-            utils.rmtree('tests/custom_dir1')
 
     def test_hg_clone(self):
         repo_dir = vcs.clone(

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -14,7 +14,6 @@ import pytest
 import subprocess
 import unittest
 
-from cookiecutter.compat import patch
 from cookiecutter import exceptions, utils, vcs
 from tests.skipif_markers import skipif_no_network
 
@@ -25,6 +24,7 @@ except KeyError:
 
 
 encoding = locale.getdefaultlocale()[1]
+
 
 @skipif_no_network
 def test_git_clone():
@@ -89,6 +89,7 @@ def test_hg_clone():
     assert os.path.isfile('cookiecutter-trytonmodule/README.rst')
     if os.path.isdir('cookiecutter-trytonmodule'):
         utils.rmtree('cookiecutter-trytonmodule')
+
 
 @skipif_no_network
 def test_vcs_not_installed(monkeypatch):

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -106,14 +106,6 @@ class TestVCSPrompt(unittest.TestCase):
             utils.rmtree('cookiecutter-trytonmodule')
         os.mkdir('cookiecutter-trytonmodule/')
 
-    @patch('cookiecutter.prompt.read_response', lambda x=u'': u'y')
-    def test_git_clone_overwrite(self):
-        repo_dir = vcs.clone(
-            'https://github.com/audreyr/cookiecutter-pypackage.git'
-        )
-        self.assertEqual(repo_dir, 'cookiecutter-pypackage')
-        self.assertTrue(os.path.isfile('cookiecutter-pypackage/README.rst'))
-
     def test_git_clone_overwrite_with_no_prompt(self):
         repo_dir = vcs.clone(
             'https://github.com/audreyr/cookiecutter-pypackage.git',

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -79,17 +79,19 @@ def test_git_clone_custom_dir():
         utils.rmtree('tests/custom_dir1')
 
 
+@skipif_no_network
+def test_hg_clone():
+    repo_dir = vcs.clone(
+        'https://bitbucket.org/pokoli/cookiecutter-trytonmodule'
+    )
+    assert repo_dir == 'cookiecutter-trytonmodule'
+    assert os.path.isfile('cookiecutter-trytonmodule/README.rst')
+    if os.path.isdir('cookiecutter-trytonmodule'):
+        utils.rmtree('cookiecutter-trytonmodule')
+
+
 @unittest.skipIf(condition=no_network, reason='Needs a network connection to GitHub/Bitbucket.')
 class TestVCS(unittest.TestCase):
-
-    def test_hg_clone(self):
-        repo_dir = vcs.clone(
-            'https://bitbucket.org/pokoli/cookiecutter-trytonmodule'
-        )
-        self.assertEqual(repo_dir, 'cookiecutter-trytonmodule')
-        self.assertTrue(os.path.isfile('cookiecutter-trytonmodule/README.rst'))
-        if os.path.isdir('cookiecutter-trytonmodule'):
-            utils.rmtree('cookiecutter-trytonmodule')
 
     @patch('cookiecutter.vcs.identify_repo', lambda x: u'stringthatisntashellcommand')
     def test_vcs_not_installed(self):

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -29,7 +29,6 @@ logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 encoding = locale.getdefaultlocale()[1]
 
 
-
 def test_identify_git_github():
     repo_url = "https://github.com/audreyr/cookiecutter-pypackage.git"
     assert vcs.identify_repo(repo_url) == "git"
@@ -41,7 +40,9 @@ def test_identify_git_github_no_extension():
 
 
 def test_identify_git_gitorious():
-    repo_url = "git@gitorious.org:cookiecutter-gitorious/cookiecutter-gitorious.git"
+    repo_url = (
+        "git@gitorious.org:cookiecutter-gitorious/cookiecutter-gitorious.git"
+    )
     assert vcs.identify_repo(repo_url) == "git"
 
 

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -106,14 +106,6 @@ class TestVCSPrompt(unittest.TestCase):
             utils.rmtree('cookiecutter-trytonmodule')
         os.mkdir('cookiecutter-trytonmodule/')
 
-    def test_git_clone_overwrite_with_no_prompt(self):
-        repo_dir = vcs.clone(
-            'https://github.com/audreyr/cookiecutter-pypackage.git',
-            no_input=True
-        )
-        self.assertEqual(repo_dir, 'cookiecutter-pypackage')
-        self.assertTrue(os.path.isfile('cookiecutter-pypackage/README.rst'))
-
     @patch('cookiecutter.prompt.read_response', lambda x=u'': u'n')
     def test_git_clone_cancel(self):
         self.assertRaises(

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -153,18 +153,5 @@ class TestVCSPrompt(unittest.TestCase):
             utils.rmtree('cookiecutter-trytonmodule')
 
 
-class TestIsVCSInstalled(unittest.TestCase):
-
-    def test_existing_repo_type(self):
-        self.assertTrue(
-            vcs.is_vcs_installed("git"),
-        )
-
-    def test_non_existing_repo_type(self):
-        self.assertFalse(
-            vcs.is_vcs_installed("stringthatisntashellcommand")
-        )
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -10,6 +10,7 @@ Tests for `cookiecutter.vcs` module.
 
 import locale
 import os
+import pytest
 import subprocess
 import unittest
 
@@ -89,17 +90,14 @@ def test_hg_clone():
     if os.path.isdir('cookiecutter-trytonmodule'):
         utils.rmtree('cookiecutter-trytonmodule')
 
-
-@unittest.skipIf(condition=no_network, reason='Needs a network connection to GitHub/Bitbucket.')
-class TestVCS(unittest.TestCase):
-
-    @patch('cookiecutter.vcs.identify_repo', lambda x: u'stringthatisntashellcommand')
-    def test_vcs_not_installed(self):
-        self.assertRaises(
-            exceptions.VCSNotInstalled,
-            vcs.clone,
-            "http://norepotypespecified.com"
-        )
+@skipif_no_network
+def test_vcs_not_installed(monkeypatch):
+    monkeypatch.setattr(
+        'cookiecutter.vcs.identify_repo',
+        lambda x: u'stringthatisntashellcommand'
+    )
+    with pytest.raises(exceptions.VCSNotInstalled):
+        vcs.clone("http://norepotypespecified.com")
 
 
 if __name__ == '__main__':

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -16,7 +16,7 @@ import subprocess
 from cookiecutter import exceptions, utils, vcs
 from tests.skipif_markers import skipif_no_network
 
-encoding = locale.getdefaultlocale()[1]
+ENCODING = locale.getdefaultlocale()[1]
 
 
 @skipif_no_network
@@ -48,7 +48,7 @@ def test_git_clone_checkout():
         stdout=subprocess.PIPE
     )
     symbolic_ref = proc.communicate()[0]
-    branch = symbolic_ref.decode(encoding).strip().split('/')[-1]
+    branch = symbolic_ref.decode(ENCODING).strip().split('/')[-1]
     assert 'console-script' == branch
 
     if os.path.isdir(git_dir):
@@ -57,15 +57,15 @@ def test_git_clone_checkout():
 
 @skipif_no_network
 def test_git_clone_custom_dir():
-    os.makedirs("tests/custom_dir1/custom_dir2/")
+    os.makedirs('tests/custom_dir1/custom_dir2/')
     repo_dir = vcs.clone(
         repo_url='https://github.com/audreyr/cookiecutter-pypackage.git',
         checkout=None,
-        clone_to_dir="tests/custom_dir1/custom_dir2/"
+        clone_to_dir='tests/custom_dir1/custom_dir2/'
     )
-    with utils.work_in("tests/custom_dir1/custom_dir2/"):
+    with utils.work_in('tests/custom_dir1/custom_dir2/'):
         test_dir = 'tests/custom_dir1/custom_dir2/cookiecutter-pypackage'
-        assert repo_dir == test_dir.replace("/", os.sep)
+        assert repo_dir == test_dir.replace('/', os.sep)
         assert os.path.isfile('cookiecutter-pypackage/README.rst')
         if os.path.isdir('cookiecutter-pypackage'):
             utils.rmtree('cookiecutter-pypackage')
@@ -91,4 +91,4 @@ def test_vcs_not_installed(monkeypatch):
         lambda x: u'stringthatisntashellcommand'
     )
     with pytest.raises(exceptions.VCSNotInstalled):
-        vcs.clone("http://norepotypespecified.com")
+        vcs.clone('http://norepotypespecified.com')

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -106,14 +106,6 @@ class TestVCSPrompt(unittest.TestCase):
             utils.rmtree('cookiecutter-trytonmodule')
         os.mkdir('cookiecutter-trytonmodule/')
 
-    @patch('cookiecutter.prompt.read_response', lambda x=u'': u'y')
-    def test_hg_clone_overwrite(self):
-        repo_dir = vcs.clone(
-            'https://bitbucket.org/pokoli/cookiecutter-trytonmodule'
-        )
-        self.assertEqual(repo_dir, 'cookiecutter-trytonmodule')
-        self.assertTrue(os.path.isfile('cookiecutter-trytonmodule/README.rst'))
-
     @patch('cookiecutter.prompt.read_response', lambda x=u'': u'n')
     def test_hg_clone_cancel(self):
         self.assertRaises(

--- a/tests/test_vcs_prompt.py
+++ b/tests/test_vcs_prompt.py
@@ -75,3 +75,14 @@ def test_hg_clone_overwrite(monkeypatch):
     )
     assert repo_dir == 'cookiecutter-trytonmodule'
     assert os.path.isfile('cookiecutter-trytonmodule/README.rst')
+
+
+@skipif_no_network
+def test_hg_clone_cancel(monkeypatch):
+    monkeypatch.setattr(
+        'cookiecutter.prompt.read_response',
+        lambda x=u'': u'n'
+    )
+
+    with pytest.raises(SystemExit):
+        vcs.clone('https://bitbucket.org/pokoli/cookiecutter-trytonmodule')

--- a/tests/test_vcs_prompt.py
+++ b/tests/test_vcs_prompt.py
@@ -62,3 +62,16 @@ def test_git_clone_cancel(monkeypatch):
 
     with pytest.raises(SystemExit):
         vcs.clone('https://github.com/audreyr/cookiecutter-pypackage.git')
+
+
+@skipif_no_network
+def test_hg_clone_overwrite(monkeypatch):
+    monkeypatch.setattr(
+        'cookiecutter.prompt.read_response',
+        lambda x=u'': u'y'
+    )
+    repo_dir = vcs.clone(
+        'https://bitbucket.org/pokoli/cookiecutter-trytonmodule'
+    )
+    assert repo_dir == 'cookiecutter-trytonmodule'
+    assert os.path.isfile('cookiecutter-trytonmodule/README.rst')

--- a/tests/test_vcs_prompt.py
+++ b/tests/test_vcs_prompt.py
@@ -9,10 +9,11 @@ test_vcs_prompt
 import os
 import pytest
 
-from cookiecutter import utils
+from cookiecutter import utils, vcs
+from tests.skipif_markers import skipif_no_network
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def clean_cookiecutter_dirs(request):
     if os.path.isdir('cookiecutter-pypackage'):
         utils.rmtree('cookiecutter-pypackage')
@@ -27,3 +28,16 @@ def clean_cookiecutter_dirs(request):
         if os.path.isdir('cookiecutter-trytonmodule'):
             utils.rmtree('cookiecutter-trytonmodule')
     request.addfinalizer(remove_cookiecutter_dirs)
+
+
+@skipif_no_network
+def test_git_clone_overwrite(monkeypatch):
+    monkeypatch.setattr(
+        'cookiecutter.prompt.read_response',
+        lambda x=u'': u'y'
+    )
+    repo_dir = vcs.clone(
+        'https://github.com/audreyr/cookiecutter-pypackage.git'
+    )
+    assert repo_dir == 'cookiecutter-pypackage'
+    assert os.path.isfile('cookiecutter-pypackage/README.rst')

--- a/tests/test_vcs_prompt.py
+++ b/tests/test_vcs_prompt.py
@@ -51,3 +51,14 @@ def test_git_clone_overwrite_with_no_prompt():
     )
     assert repo_dir == 'cookiecutter-pypackage'
     assert os.path.isfile('cookiecutter-pypackage/README.rst')
+
+
+@skipif_no_network
+def test_git_clone_cancel(monkeypatch):
+    monkeypatch.setattr(
+        'cookiecutter.prompt.read_response',
+        lambda x=u'': u'n'
+    )
+
+    with pytest.raises(SystemExit):
+        vcs.clone('https://github.com/audreyr/cookiecutter-pypackage.git')

--- a/tests/test_vcs_prompt.py
+++ b/tests/test_vcs_prompt.py
@@ -41,3 +41,13 @@ def test_git_clone_overwrite(monkeypatch):
     )
     assert repo_dir == 'cookiecutter-pypackage'
     assert os.path.isfile('cookiecutter-pypackage/README.rst')
+
+
+@skipif_no_network
+def test_git_clone_overwrite_with_no_prompt():
+    repo_dir = vcs.clone(
+        'https://github.com/audreyr/cookiecutter-pypackage.git',
+        no_input=True
+    )
+    assert repo_dir == 'cookiecutter-pypackage'
+    assert os.path.isfile('cookiecutter-pypackage/README.rst')

--- a/tests/test_vcs_prompt.py
+++ b/tests/test_vcs_prompt.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_vcs_prompt
+---------------
+"""
+
+import os
+import pytest
+
+from cookiecutter import utils
+
+
+@pytest.fixture
+def clean_cookiecutter_dirs(request):
+    if os.path.isdir('cookiecutter-pypackage'):
+        utils.rmtree('cookiecutter-pypackage')
+    os.mkdir('cookiecutter-pypackage/')
+    if os.path.isdir('cookiecutter-trytonmodule'):
+        utils.rmtree('cookiecutter-trytonmodule')
+    os.mkdir('cookiecutter-trytonmodule/')
+
+    def remove_cookiecutter_dirs():
+        if os.path.isdir('cookiecutter-pypackage'):
+            utils.rmtree('cookiecutter-pypackage')
+        if os.path.isdir('cookiecutter-trytonmodule'):
+            utils.rmtree('cookiecutter-trytonmodule')
+    request.addfinalizer(remove_cookiecutter_dirs)


### PR DESCRIPTION
Split the former classes of `test_vcs.py` into separate modules and convert them to `py.test`:
* `test_identify_repo.py`
* `test_is_vcs_installed.py`
* `test_vcs.py`
* `test_vcs_prompt.py`

This PR does not introduce any new concepts. Instead it reuses the `skip_if_markers` of master and `monkeypatch`. I highly recommend running these tests on your local setup due to the skipif markers.

As this PR is rather large I completely understand if you decide against merging it for #410.

Please let me know your thoughts! :smiley: