### PR TITLE
pip is preferred for Python packaging over easy_install

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,13 +6,15 @@ At the command line:
 
 .. code-block:: bash
 
-    $ [sudo] easy_install cookiecutter
-
-Or, if you have pip (the Python package installer tool):
+    $ [sudo] pip install cookiecutter
+    
+Or, if you do not have pip:
 
 .. code-block:: bash
 
-    $ [sudo] pip install cookiecutter
+    $ [sudo] easy_install cookiecutter
+
+Though, pip is recommended.
 
 Upgrading from 0.6.4 to 0.7.0 or greater
 -----------------------------------------


### PR DESCRIPTION
https://python-packaging-user-guide.readthedocs.org/en/latest/current.html