### PR TITLE
Added --rc-file option to load specific or no user config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ htmlcov/
 
 # Local env
 .envs
+.venv

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -16,7 +16,7 @@ import logging
 
 import click
 
-from cookiecutter import __version__
+from cookiecutter import __version__, config
 from cookiecutter.main import cookiecutter
 
 logger = logging.getLogger(__name__)
@@ -41,6 +41,10 @@ def print_version(context, param, value):
          'file content',
 )
 @click.option(
+    '--rc-file', metavar='FILE', default=config.USER_CONFIG_PATH,
+    help='Path of user configuration file (empty for none)',
+)
+@click.option(
     '-c', '--checkout',
     help='branch, tag or commit to checkout after git clone',
 )
@@ -53,7 +57,7 @@ def print_version(context, param, value):
     '-v', '--verbose',
     is_flag=True, help='Print debug information', default=False
 )
-def main(template, no_input, checkout, verbose):
+def main(template, no_input, checkout, verbose, rc_file):
     """Create a project from a Cookiecutter project template (TEMPLATE)."""
     if verbose:
         logging.basicConfig(
@@ -67,4 +71,4 @@ def main(template, no_input, checkout, verbose):
             level=logging.INFO
         )
 
-    cookiecutter(template, checkout, no_input)
+    cookiecutter(template, checkout, no_input, rc_file=rc_file)

--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -27,6 +27,9 @@ DEFAULT_CONFIG = {
     'default_context': {}
 }
 
+# TODO: test on windows...
+USER_CONFIG_PATH = '~/.cookiecutterrc'
+
 
 def get_config(config_path):
     """
@@ -50,15 +53,15 @@ def get_config(config_path):
     return config_dict
 
 
-def get_user_config():
+def get_user_config(rc_file=USER_CONFIG_PATH):
     """
-    Retrieve config from the user's ~/.cookiecutterrc, if it exists.
-    Otherwise, return None.
+    Retrieve config from the given path, if it exists.
+    Otherwise, return a deep copy of the defaults.
+
+    :param rc_file: Path to the user configuration file
     """
-
-    # TODO: test on windows...
-    USER_CONFIG_PATH = os.path.expanduser('~/.cookiecutterrc')
-
-    if os.path.exists(USER_CONFIG_PATH):
-        return get_config(USER_CONFIG_PATH)
-    return copy.copy(DEFAULT_CONFIG)
+    rc_file = os.path.expanduser(rc_file or '')
+    if rc_file and os.path.exists(rc_file):
+        return get_config(rc_file)
+    else:
+        return copy.copy(DEFAULT_CONFIG)

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -52,7 +52,8 @@ def expand_abbreviations(template, config_dict):
     return template
 
 
-def cookiecutter(template, checkout=None, no_input=False, extra_context=None, rc_file=USER_CONFIG_PATH):
+def cookiecutter(template, checkout=None, no_input=False, extra_context=None,
+                 rc_file=USER_CONFIG_PATH):
     """
     API equivalent to using Cookiecutter at the command line.
 

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -15,7 +15,7 @@ from __future__ import unicode_literals
 import logging
 import os
 
-from .config import get_user_config
+from .config import get_user_config, USER_CONFIG_PATH
 from .prompt import prompt_for_config
 from .generate import generate_context, generate_files
 from .vcs import clone
@@ -52,7 +52,7 @@ def expand_abbreviations(template, config_dict):
     return template
 
 
-def cookiecutter(template, checkout=None, no_input=False, extra_context=None):
+def cookiecutter(template, checkout=None, no_input=False, extra_context=None, rc_file=USER_CONFIG_PATH):
     """
     API equivalent to using Cookiecutter at the command line.
 
@@ -62,11 +62,12 @@ def cookiecutter(template, checkout=None, no_input=False, extra_context=None):
     :param no_input: Prompt the user at command line for manual configuration?
     :param extra_context: A dictionary of context that overrides default
         and user configuration.
+    :param rc_file: Path to the user configuration file
     """
 
     # Get user config from ~/.cookiecutterrc or equivalent
     # If no config file, sensible defaults from config.DEFAULT_CONFIG are used
-    config_dict = get_user_config()
+    config_dict = get_user_config(rc_file)
 
     template = expand_abbreviations(template, config_dict)
 

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -68,6 +68,14 @@ Possible settings are:
   The `gh` (github) and `bb` (bitbucket) abbreviations shown above are actually
   built in, and can be used without defining them yourself.
 
+The default location ``~/.cookiecutterrc`` can be changed by using the
+``--rc-file`` command line option (1.1.0+). Passing an empty value will prevent
+the loading of user settings altogether and use the defaults instead. This is
+useful when writing integration tests for your own cookiecutters, since then
+you have no interference from the user account you run them in. Also, if you
+work with many different profiles under one user account (like in a CI server),
+the ability to load a specific one can come in handy.
+
 Calling Cookiecutter Functions From Python
 ------------------------------------------
 

--- a/tests/test_get_user_config.py
+++ b/tests/test_get_user_config.py
@@ -18,6 +18,16 @@ import pytest
 from cookiecutter import config
 from cookiecutter.exceptions import InvalidConfiguration
 
+VALID_CONFIG_PATH = 'tests/test-config/valid-config.yaml'
+VALID_CONFIG = {
+    'cookiecutters_dir': '/home/example/some-path-to-templates',
+    'default_context': {
+        'full_name': 'Firstname Lastname',
+        'email': 'firstname.lastname@gmail.com',
+        'github_username': 'example'
+    }
+}
+
 
 @pytest.fixture(scope='module')
 def user_config_path():
@@ -63,17 +73,28 @@ def test_get_user_config_valid(user_config_path):
     """
     Get config from a valid ~/.cookiecutterrc file
     """
-    shutil.copy('tests/test-config/valid-config.yaml', user_config_path)
+    shutil.copy(VALID_CONFIG_PATH, user_config_path)
     conf = config.get_user_config()
-    expected_conf = {
-        'cookiecutters_dir': '/home/example/some-path-to-templates',
-        'default_context': {
-            'full_name': 'Firstname Lastname',
-            'email': 'firstname.lastname@gmail.com',
-            'github_username': 'example'
-        }
-    }
-    assert conf == expected_conf
+    assert conf == VALID_CONFIG
+
+
+def test_get_user_config_from_path():
+    """
+    Get config from a valid ~/.cookiecutterrc file directly
+    """
+    conf = config.get_user_config(VALID_CONFIG_PATH)
+    assert conf == VALID_CONFIG
+
+
+@pytest.mark.usefixtures('back_up_rc')
+def test_get_user_config_no_rc(user_config_path):
+    """
+    Do NOT get config from a valid ~/.cookiecutterrc file
+    """
+    shutil.copy(VALID_CONFIG_PATH, user_config_path)
+    for rc_file in (None, '', 'this-will-not-ever-exist'):
+        conf = config.get_user_config(rc_file)
+        assert conf == config.DEFAULT_CONFIG
 
 
 @pytest.mark.usefixtures('back_up_rc')


### PR DESCRIPTION
Motivation (use-cases):
 * isolate unit tests of cookiecutter templates from user home
 * Selection of different config sets in a CI server or similar