### PR TITLE
Hackebrot merge copy without render

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -242,8 +242,7 @@ def generate_files(repo_dir, context=None, output_dir='.'):
             # recursively
             dirs[:] = render_dirs
             for d in dirs:
-                in_dir = os.path.join(root, d)
-                unrendered_dir = os.path.join(project_dir, in_dir)
+                unrendered_dir = os.path.join(project_dir, root, d)
                 render_and_create_dir(unrendered_dir, context, output_dir)
 
             for f in files:

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -37,7 +37,7 @@ def copy_without_render(path, context):
     :param context: cookiecutter context.
     """
     try:
-        for dont_render in context["cookiecutter"]["_copy_without_render"]:
+        for dont_render in context['cookiecutter']['_copy_without_render']:
             if fnmatch.fnmatch(path, os.path.relpath(dont_render)):
                 return True
     except KeyError:
@@ -233,8 +233,8 @@ def generate_files(repo_dir, context=None, output_dir='.'):
                 indir = os.path.normpath(os.path.join(root, copy_dir))
                 outdir = os.path.normpath(os.path.join(project_dir, indir))
                 logging.debug(
-                    "Copying dir {0} to {1} without rendering"
-                    "".format(indir, outdir)
+                    'Copying dir {0} to {1} without rendering'
+                    ''.format(indir, outdir)
                 )
                 shutil.copytree(indir, outdir)
 
@@ -253,8 +253,8 @@ def generate_files(repo_dir, context=None, output_dir='.'):
                     outfile_rendered = outfile_tmpl.render(**context)
                     outfile = os.path.join(project_dir, outfile_rendered)
                     logging.debug(
-                        "Copying file {0} to {1} without rendering"
-                        "".format(infile, outfile)
+                        'Copying file {0} to {1} without rendering'
+                        ''.format(infile, outfile)
                     )
                     shutil.copyfile(infile, outfile)
                     shutil.copymode(infile, outfile)

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -15,7 +15,6 @@ import json
 import logging
 import os
 import shutil
-import sys
 
 from jinja2 import FileSystemLoader, Template
 from jinja2.environment import Environment
@@ -234,7 +233,8 @@ def generate_files(repo_dir, context=None, output_dir='.'):
                 indir = os.path.normpath(os.path.join(root, copy_dir))
                 outdir = os.path.normpath(os.path.join(project_dir, indir))
                 logging.debug(
-                    "Copying dir {0} to {1} without rendering".format(indir, outdir)
+                    "Copying dir {0} to {1} without rendering"
+                    "".format(indir, outdir)
                 )
                 shutil.copytree(indir, outdir)
 
@@ -242,16 +242,19 @@ def generate_files(repo_dir, context=None, output_dir='.'):
             # recursively
             dirs[:] = render_dirs
             for d in dirs:
-                unrendered_dir = os.path.join(project_dir, os.path.join(root, d))
+                in_dir = os.path.join(root, d)
+                unrendered_dir = os.path.join(project_dir, in_dir)
                 render_and_create_dir(unrendered_dir, context, output_dir)
 
             for f in files:
                 infile = os.path.normpath(os.path.join(root, f))
                 if copy_without_render(infile, context):
                     outfile_tmpl = Template(infile)
-                    outfile = os.path.join(project_dir, outfile_tmpl.render(**context))
+                    outfile_rendered = outfile_tmpl.render(**context)
+                    outfile = os.path.join(project_dir, outfile_rendered)
                     logging.debug(
-                        "Copying file {0} to {1} without rendering".format(infile, outfile)
+                        "Copying file {0} to {1} without rendering"
+                        "".format(infile, outfile)
                     )
                     shutil.copyfile(infile, outfile)
                     shutil.copymode(infile, outfile)

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -38,7 +38,7 @@ def copy_without_render(path, context):
     """
     try:
         for dont_render in context['cookiecutter']['_copy_without_render']:
-            if fnmatch.fnmatch(path, os.path.relpath(dont_render)):
+            if fnmatch.fnmatch(path, dont_render):
                 return True
     except KeyError:
         return False
@@ -224,7 +224,7 @@ def generate_files(repo_dir, context=None, output_dir='.'):
                 # We check the full path, because that's how it can be
                 # specified in the ``_copy_without_render`` setting, but
                 # we store just the dir name
-                if copy_without_render(os.path.relpath(d_), context):
+                if copy_without_render(d_, context):
                     copy_dirs.append(d)
                 else:
                     render_dirs.append(d)

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -26,6 +26,10 @@ def prompt_for_config(context, no_input=False):
     env = Environment()
 
     for key, raw in iteritems(context['cookiecutter']):
+        if key.startswith("_"):
+            cookiecutter_dict[key] = raw
+            continue
+
         raw = raw if is_string(raw) else str(raw)
         val = env.from_string(raw).render(cookiecutter=cookiecutter_dict)
 

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -26,7 +26,7 @@ def prompt_for_config(context, no_input=False):
     env = Environment()
 
     for key, raw in iteritems(context['cookiecutter']):
-        if key.startswith("_"):
+        if key.startswith('_'):
             cookiecutter_dict[key] = raw
             continue
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -27,6 +27,18 @@ Or this::
 
 See http://jinja.pocoo.org/docs/templates/#escaping for more info.
 
+You can also use the `_copy_without_render` key in your `cookiecutter.json`
+file, which accepts Unix shell-style wildcards::
+
+    {
+        "repo_name": "sample",
+        "_copy_without_render": [
+            "*.html",
+            "*not_rendered_dir",
+            "rendered_dir/not_rendered_file.ini"
+        ]
+    }
+
 Other common issues
 -------------------
 

--- a/tests/test-generate-copy-without-render/{{cookiecutter.repo_name}}/README.rst
+++ b/tests/test-generate-copy-without-render/{{cookiecutter.repo_name}}/README.rst
@@ -1,0 +1,5 @@
+============
+Fake Project
+============
+
+{{cookiecutter.render_test}}

--- a/tests/test-generate-copy-without-render/{{cookiecutter.repo_name}}/README.txt
+++ b/tests/test-generate-copy-without-render/{{cookiecutter.repo_name}}/README.txt
@@ -1,0 +1,5 @@
+============
+Fake Project
+============
+
+{{cookiecutter.render_test}}

--- a/tests/test-generate-copy-without-render/{{cookiecutter.repo_name}}/rendered/not_rendered.yml
+++ b/tests/test-generate-copy-without-render/{{cookiecutter.repo_name}}/rendered/not_rendered.yml
@@ -1,0 +1,2 @@
+---
+- name: {{cookiecutter.render_test}}

--- a/tests/test-generate-copy-without-render/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-not-rendered/README.rst
+++ b/tests/test-generate-copy-without-render/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-not-rendered/README.rst
@@ -1,0 +1,5 @@
+============
+Fake Project
+============
+
+{{cookiecutter.render_test}}

--- a/tests/test-generate-copy-without-render/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-rendered/README.rst
+++ b/tests/test-generate-copy-without-render/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-rendered/README.rst
@@ -1,0 +1,5 @@
+============
+Fake Project
+============
+
+{{cookiecutter.render_test}}

--- a/tests/test-generate-copy-without-render/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-rendered/README.txt
+++ b/tests/test-generate-copy-without-render/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-rendered/README.txt
@@ -1,0 +1,5 @@
+============
+Fake Project
+============
+
+{{cookiecutter.render_test}}

--- a/tests/test_generate_copy_without_render.py
+++ b/tests/test_generate_copy_without_render.py
@@ -25,7 +25,7 @@ def remove_test_dir(request):
     request.addfinalizer(fin_remove_test_dir)
 
 
-@pytest.mark.usefixtures('remove_test_dir')
+@pytest.mark.usefixtures('clean_system', 'remove_test_dir')
 def test_generate_copy_without_render_extensions():
     generate.generate_files(
         context={

--- a/tests/test_generate_copy_without_render.py
+++ b/tests/test_generate_copy_without_render.py
@@ -1,3 +1,18 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_generate_copy_without_render
+---------------------------------
+"""
+
+from __future__ import unicode_literals
+import os
+import shutil
+
+from cookiecutter import generate
+
+
 def test_generate_copy_without_render_extensions():
     generate.generate_files(
         context={

--- a/tests/test_generate_copy_without_render.py
+++ b/tests/test_generate_copy_without_render.py
@@ -1,0 +1,40 @@
+def test_generate_copy_without_render_extensions(self):
+    generate.generate_files(
+        context={
+            'cookiecutter': {
+                "repo_name": "test_copy_without_render",
+                "render_test": "I have been rendered!",
+                "_copy_without_render": [
+                    "*not-rendered",
+                    "rendered/not_rendered.yml",
+                    "*.txt",
+                ]}
+        },
+        repo_dir='tests/test-generate-copy-without-render'
+    )
+
+    self.assertIn("{{cookiecutter.repo_name}}-not-rendered",
+                  os.listdir("test_copy_without_render"))
+    self.assertIn("test_copy_without_render-rendered",
+                  os.listdir("test_copy_without_render"))
+
+    with open("test_copy_without_render/README.txt") as f:
+        self.assertIn("{{cookiecutter.render_test}}", f.read())
+
+    with open("test_copy_without_render/README.rst") as f:
+        self.assertIn("I have been rendered!", f.read())
+
+    with open("test_copy_without_render/test_copy_without_render-rendered/README.txt") as f:
+        self.assertIn("{{cookiecutter.render_test}}", f.read())
+
+    with open("test_copy_without_render/test_copy_without_render-rendered/README.rst") as f:
+        self.assertIn("I have been rendered", f.read())
+
+    with open("test_copy_without_render/{{cookiecutter.repo_name}}-not-rendered/README.rst") as f:
+        self.assertIn("{{cookiecutter.render_test}}", f.read())
+
+    with open("test_copy_without_render/rendered/not_rendered.yml") as f:
+        self.assertIn("{{cookiecutter.render_test}}", f.read())
+
+    if os.path.exists('test_copy_without_render'):
+        shutil.rmtree('test_copy_without_render')

--- a/tests/test_generate_copy_without_render.py
+++ b/tests/test_generate_copy_without_render.py
@@ -30,42 +30,42 @@ def test_generate_copy_without_render_extensions():
     generate.generate_files(
         context={
             'cookiecutter': {
-                "repo_name": "test_copy_without_render",
-                "render_test": "I have been rendered!",
-                "_copy_without_render": [
-                    "*not-rendered",
-                    "rendered/not_rendered.yml",
-                    "*.txt",
+                'repo_name': 'test_copy_without_render',
+                'render_test': 'I have been rendered!',
+                '_copy_without_render': [
+                    '*not-rendered',
+                    'rendered/not_rendered.yml',
+                    '*.txt',
                 ]}
         },
         repo_dir='tests/test-generate-copy-without-render'
     )
 
-    dir_contents = os.listdir("test_copy_without_render")
+    dir_contents = os.listdir('test_copy_without_render')
 
-    assert "{{cookiecutter.repo_name}}-not-rendered" in dir_contents
-    assert "test_copy_without_render-rendered" in dir_contents
+    assert '{{cookiecutter.repo_name}}-not-rendered' in dir_contents
+    assert 'test_copy_without_render-rendered' in dir_contents
 
-    with open("test_copy_without_render/README.txt") as f:
-        assert "{{cookiecutter.render_test}}" in f.read()
+    with open('test_copy_without_render/README.txt') as f:
+        assert '{{cookiecutter.render_test}}' in f.read()
 
-    with open("test_copy_without_render/README.rst") as f:
-        assert "I have been rendered!" in f.read()
+    with open('test_copy_without_render/README.rst') as f:
+        assert 'I have been rendered!' in f.read()
 
-    with open("test_copy_without_render/"
-              "test_copy_without_render-rendered/"
-              "README.txt") as f:
-        assert "{{cookiecutter.render_test}}" in f.read()
+    with open('test_copy_without_render/'
+              'test_copy_without_render-rendered/'
+              'README.txt') as f:
+        assert '{{cookiecutter.render_test}}' in f.read()
 
-    with open("test_copy_without_render/"
-              "test_copy_without_render-rendered/"
-              "README.rst") as f:
-        assert "I have been rendered" in f.read()
+    with open('test_copy_without_render/'
+              'test_copy_without_render-rendered/'
+              'README.rst') as f:
+        assert 'I have been rendered' in f.read()
 
-    with open("test_copy_without_render/"
-              "{{cookiecutter.repo_name}}-not-rendered/"
-              "README.rst") as f:
-        assert "{{cookiecutter.render_test}}" in f.read()
+    with open('test_copy_without_render/'
+              '{{cookiecutter.repo_name}}-not-rendered/'
+              'README.rst') as f:
+        assert '{{cookiecutter.render_test}}' in f.read()
 
-    with open("test_copy_without_render/rendered/not_rendered.yml") as f:
-        assert "{{cookiecutter.render_test}}" in f.read()
+    with open('test_copy_without_render/rendered/not_rendered.yml') as f:
+        assert '{{cookiecutter.render_test}}' in f.read()

--- a/tests/test_generate_copy_without_render.py
+++ b/tests/test_generate_copy_without_render.py
@@ -12,6 +12,7 @@ import pytest
 import shutil
 
 from cookiecutter import generate
+from cookiecutter import utils
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_generate_copy_without_render.py
+++ b/tests/test_generate_copy_without_render.py
@@ -41,8 +41,10 @@ def test_generate_copy_without_render_extensions():
         repo_dir='tests/test-generate-copy-without-render'
     )
 
-    assert "{{cookiecutter.repo_name}}-not-rendered" in os.listdir("test_copy_without_render")
-    assert "test_copy_without_render-rendered" in os.listdir("test_copy_without_render")
+    dir_contents = os.listdir("test_copy_without_render")
+
+    assert "{{cookiecutter.repo_name}}-not-rendered" in dir_contents
+    assert "test_copy_without_render-rendered" in dir_contents
 
     with open("test_copy_without_render/README.txt") as f:
         assert "{{cookiecutter.render_test}}" in f.read()
@@ -50,13 +52,19 @@ def test_generate_copy_without_render_extensions():
     with open("test_copy_without_render/README.rst") as f:
         assert "I have been rendered!" in f.read()
 
-    with open("test_copy_without_render/test_copy_without_render-rendered/README.txt") as f:
+    with open("test_copy_without_render/"
+              "test_copy_without_render-rendered/"
+              "README.txt") as f:
         assert "{{cookiecutter.render_test}}" in f.read()
 
-    with open("test_copy_without_render/test_copy_without_render-rendered/README.rst") as f:
+    with open("test_copy_without_render/"
+              "test_copy_without_render-rendered/"
+              "README.rst") as f:
         assert "I have been rendered" in f.read()
 
-    with open("test_copy_without_render/{{cookiecutter.repo_name}}-not-rendered/README.rst") as f:
+    with open("test_copy_without_render/"
+              "{{cookiecutter.repo_name}}-not-rendered/"
+              "README.rst") as f:
         assert "{{cookiecutter.render_test}}" in f.read()
 
     with open("test_copy_without_render/rendered/not_rendered.yml") as f:

--- a/tests/test_generate_copy_without_render.py
+++ b/tests/test_generate_copy_without_render.py
@@ -8,9 +8,21 @@ test_generate_copy_without_render
 
 from __future__ import unicode_literals
 import os
+import pytest
 import shutil
 
 from cookiecutter import generate
+
+
+@pytest.fixture(scope='function')
+def remove_test_dir(request):
+    """
+    Remove the folder that is created by the test.
+    """
+    def fin_remove_test_dir():
+        if os.path.exists('test_copy_without_render'):
+            utils.rmtree('test_copy_without_render')
+    request.addfinalizer(fin_remove_test_dir)
 
 
 def test_generate_copy_without_render_extensions():

--- a/tests/test_generate_copy_without_render.py
+++ b/tests/test_generate_copy_without_render.py
@@ -1,4 +1,4 @@
-def test_generate_copy_without_render_extensions(self):
+def test_generate_copy_without_render_extensions():
     generate.generate_files(
         context={
             'cookiecutter': {
@@ -13,28 +13,26 @@ def test_generate_copy_without_render_extensions(self):
         repo_dir='tests/test-generate-copy-without-render'
     )
 
-    self.assertIn("{{cookiecutter.repo_name}}-not-rendered",
-                  os.listdir("test_copy_without_render"))
-    self.assertIn("test_copy_without_render-rendered",
-                  os.listdir("test_copy_without_render"))
+    assert "{{cookiecutter.repo_name}}-not-rendered" in os.listdir("test_copy_without_render")
+    assert "test_copy_without_render-rendered" in os.listdir("test_copy_without_render")
 
     with open("test_copy_without_render/README.txt") as f:
-        self.assertIn("{{cookiecutter.render_test}}", f.read())
+        assert "{{cookiecutter.render_test}}" in f.read()
 
     with open("test_copy_without_render/README.rst") as f:
-        self.assertIn("I have been rendered!", f.read())
+        assert "I have been rendered!" in f.read()
 
     with open("test_copy_without_render/test_copy_without_render-rendered/README.txt") as f:
-        self.assertIn("{{cookiecutter.render_test}}", f.read())
+        assert "{{cookiecutter.render_test}}" in f.read()
 
     with open("test_copy_without_render/test_copy_without_render-rendered/README.rst") as f:
-        self.assertIn("I have been rendered", f.read())
+        assert "I have been rendered" in f.read()
 
     with open("test_copy_without_render/{{cookiecutter.repo_name}}-not-rendered/README.rst") as f:
-        self.assertIn("{{cookiecutter.render_test}}", f.read())
+        assert "{{cookiecutter.render_test}}" in f.read()
 
     with open("test_copy_without_render/rendered/not_rendered.yml") as f:
-        self.assertIn("{{cookiecutter.render_test}}", f.read())
+        assert "{{cookiecutter.render_test}}" in f.read()
 
     if os.path.exists('test_copy_without_render'):
         shutil.rmtree('test_copy_without_render')

--- a/tests/test_generate_copy_without_render.py
+++ b/tests/test_generate_copy_without_render.py
@@ -25,6 +25,7 @@ def remove_test_dir(request):
     request.addfinalizer(fin_remove_test_dir)
 
 
+@pytest.mark.usefixtures('remove_test_dir')
 def test_generate_copy_without_render_extensions():
     generate.generate_files(
         context={

--- a/tests/test_generate_copy_without_render.py
+++ b/tests/test_generate_copy_without_render.py
@@ -9,7 +9,6 @@ test_generate_copy_without_render
 from __future__ import unicode_literals
 import os
 import pytest
-import shutil
 
 from cookiecutter import generate
 from cookiecutter import utils
@@ -62,6 +61,3 @@ def test_generate_copy_without_render_extensions():
 
     with open("test_copy_without_render/rendered/not_rendered.yml") as f:
         assert "{{cookiecutter.render_test}}" in f.read()
-
-    if os.path.exists('test_copy_without_render'):
-        shutil.rmtree('test_copy_without_render')

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -99,6 +99,17 @@ class TestPrompt(object):
         cookiecutter_dict = prompt.prompt_for_config(context)
         assert cookiecutter_dict == exp_cookiecutter_dict
 
+    def test_dont_prompt_for_private_context_var(self, monkeypatch):
+        monkeypatch.setattr(
+            'cookiecutter.prompt.read_response',
+            lambda x: pytest.fail(
+                'Should not try to read a response for private context var'
+            )
+        )
+        context = {"cookiecutter": {"_copy_without_render": ["*.html"]}}
+        cookiecutter_dict = prompt.prompt_for_config(context)
+        assert cookiecutter_dict == {"_copy_without_render": ["*.html"]}
+
 
 class TestQueryAnswers(object):
     @pytest.fixture(params=[u'y', u'ye', u'yes'])

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -160,4 +160,3 @@ class TestQueryDefaults(object):
         )
         with pytest.raises(ValueError):
             prompt.query_yes_no('Blah?', default='yn')
-

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -43,58 +43,58 @@ class TestPrompt(object):
             'cookiecutter.prompt.read_response',
             lambda x=u'': u'Audrey Roy'
         )
-        context = {"cookiecutter": {"full_name": "Your Name"}}
+        context = {'cookiecutter': {'full_name': 'Your Name'}}
 
         cookiecutter_dict = prompt.prompt_for_config(context)
-        assert cookiecutter_dict == {"full_name": u"Audrey Roy"}
+        assert cookiecutter_dict == {'full_name': u'Audrey Roy'}
 
     def test_prompt_for_config_unicode(self, monkeypatch):
         monkeypatch.setattr(
             'cookiecutter.prompt.read_response',
             lambda x=u'': u'Pizzä ïs Gööd'
         )
-        context = {"cookiecutter": {"full_name": "Your Name"}}
+        context = {'cookiecutter': {'full_name': 'Your Name'}}
 
         cookiecutter_dict = prompt.prompt_for_config(context)
-        assert cookiecutter_dict == {"full_name": u"Pizzä ïs Gööd"}
+        assert cookiecutter_dict == {'full_name': u'Pizzä ïs Gööd'}
 
     def test_unicode_prompt_for_config_unicode(self, monkeypatch):
         monkeypatch.setattr(
             'cookiecutter.prompt.read_response',
             lambda x=u'': u'Pizzä ïs Gööd'
         )
-        context = {"cookiecutter": {"full_name": u"Řekni či napiš své jméno"}}
+        context = {'cookiecutter': {'full_name': u'Řekni či napiš své jméno'}}
 
         cookiecutter_dict = prompt.prompt_for_config(context)
-        assert cookiecutter_dict == {"full_name": u"Pizzä ïs Gööd"}
+        assert cookiecutter_dict == {'full_name': u'Pizzä ïs Gööd'}
 
     def test_unicode_prompt_for_default_config_unicode(self, monkeypatch):
         monkeypatch.setattr(
             'cookiecutter.prompt.read_response',
             lambda x=u'': u'\n'
         )
-        context = {"cookiecutter": {"full_name": u"Řekni či napiš své jméno"}}
+        context = {'cookiecutter': {'full_name': u'Řekni či napiš své jméno'}}
 
         cookiecutter_dict = prompt.prompt_for_config(context)
-        assert cookiecutter_dict == {"full_name": u"Řekni či napiš své jméno"}
+        assert cookiecutter_dict == {'full_name': u'Řekni či napiš své jméno'}
 
     def test_unicode_prompt_for_templated_config(self, monkeypatch):
         monkeypatch.setattr(
             'cookiecutter.prompt.read_response',
             lambda x=u'': u'\n'
         )
-        context = {"cookiecutter": OrderedDict([
+        context = {'cookiecutter': OrderedDict([
             (
-                "project_name",
-                u"A New Project"
+                'project_name',
+                u'A New Project'
             ), (
-                "pkg_name",
-                u"{{ cookiecutter.project_name|lower|replace(' ', '') }}"
+                'pkg_name',
+                u'{{ cookiecutter.project_name|lower|replace(" ", "") }}'
             )
         ])}
 
         exp_cookiecutter_dict = {
-            "project_name": u"A New Project", "pkg_name": u"anewproject"
+            'project_name': u'A New Project', 'pkg_name': u'anewproject'
         }
         cookiecutter_dict = prompt.prompt_for_config(context)
         assert cookiecutter_dict == exp_cookiecutter_dict
@@ -106,9 +106,9 @@ class TestPrompt(object):
                 'Should not try to read a response for private context var'
             )
         )
-        context = {"cookiecutter": {"_copy_without_render": ["*.html"]}}
+        context = {'cookiecutter': {'_copy_without_render': ['*.html']}}
         cookiecutter_dict = prompt.prompt_for_config(context)
-        assert cookiecutter_dict == {"_copy_without_render": ["*.html"]}
+        assert cookiecutter_dict == {'_copy_without_render': ['*.html']}
 
 
 class TestQueryAnswers(object):
@@ -121,14 +121,14 @@ class TestQueryAnswers(object):
 
     @pytest.mark.usefixtures('patch_read_response')
     def test_query(self):
-        assert prompt.query_yes_no("Blah?")
+        assert prompt.query_yes_no('Blah?')
 
     def test_query_n(self, monkeypatch):
         monkeypatch.setattr(
             'cookiecutter.prompt.read_response',
             lambda x=u'': u'n'
         )
-        assert not prompt.query_yes_no("Blah?")
+        assert not prompt.query_yes_no('Blah?')
 
 
 class TestQueryDefaults(object):
@@ -137,21 +137,21 @@ class TestQueryDefaults(object):
             'cookiecutter.prompt.read_response',
             lambda x=u'': u'y'
         )
-        assert prompt.query_yes_no("Blah?", default=None)
+        assert prompt.query_yes_no('Blah?', default=None)
 
     def test_query_n_none_default(self, monkeypatch):
         monkeypatch.setattr(
             'cookiecutter.prompt.read_response',
             lambda x=u'': u'n'
         )
-        assert not prompt.query_yes_no("Blah?", default=None)
+        assert not prompt.query_yes_no('Blah?', default=None)
 
     def test_query_no_default(self, monkeypatch):
         monkeypatch.setattr(
             'cookiecutter.prompt.read_response',
             lambda x=u'': u''
         )
-        assert not prompt.query_yes_no("Blah?", default='no')
+        assert not prompt.query_yes_no('Blah?', default='no')
 
     def test_query_bad_default(self, monkeypatch):
         monkeypatch.setattr(
@@ -159,5 +159,5 @@ class TestQueryDefaults(object):
             lambda x=u'': u'junk'
         )
         with pytest.raises(ValueError):
-            prompt.query_yes_no("Blah?", default='yn')
+            prompt.query_yes_no('Blah?', default='yn')
 


### PR DESCRIPTION
Continue the work on #132 and #184.

Resolving the conflicts was pointless, so I manually merged in the changes. Credit goes to @osantana and @LucianU :bow:

I converted the former test to py.test, fixed flake8 and changed string literals to single quotes.

According to the previous PRs we should get failures on appveyor. I'll look into them in the next days. Tests are fine though on Ubuntu and the coverage does not drop. (We need codecov comments :cry: #416)

cc: @audreyr @pydanny 