### PR TITLE
Enriched context for hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ htmlcov/
 
 # Local env
 .envs
+.venv

--- a/cookiecutter/__init__.py
+++ b/cookiecutter/__init__.py
@@ -9,7 +9,7 @@ Main package for Cookiecutter.
 """
 from .compat import OLD_PY2
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 if OLD_PY2:
     msg = 'Python 2.6 support was removed from cookiecutter in release 1.0.0.'

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -21,6 +21,11 @@ from cookiecutter.main import cookiecutter
 
 logger = logging.getLogger(__name__)
 
+# The `click` custom context settings
+CONTEXT_SETTINGS = dict(
+    help_option_names=['-h', '--help'],
+)
+
 
 def print_version(context, param, value):
     if not value or context.resilient_parsing:
@@ -33,7 +38,7 @@ def print_version(context, param, value):
     context.exit()
 
 
-@click.command()
+@click.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('template')
 @click.option(
     '--no-input', is_flag=True,

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -16,7 +16,7 @@ import logging
 
 import click
 
-from cookiecutter import __version__
+from cookiecutter import __version__, config
 from cookiecutter.main import cookiecutter
 
 logger = logging.getLogger(__name__)
@@ -41,6 +41,10 @@ def print_version(context, param, value):
          'file content',
 )
 @click.option(
+    '--rc-file', metavar='FILE', default=config.USER_CONFIG_PATH,
+    help='Path of user configuration file (empty for none)',
+)
+@click.option(
     '-c', '--checkout',
     help='branch, tag or commit to checkout after git clone',
 )
@@ -53,7 +57,7 @@ def print_version(context, param, value):
     '-v', '--verbose',
     is_flag=True, help='Print debug information', default=False
 )
-def main(template, no_input, checkout, verbose):
+def main(template, no_input, checkout, verbose, rc_file):
     """Create a project from a Cookiecutter project template (TEMPLATE)."""
     if verbose:
         logging.basicConfig(
@@ -67,7 +71,7 @@ def main(template, no_input, checkout, verbose):
             level=logging.INFO
         )
 
-    cookiecutter(template, checkout, no_input, extra_globals=dict(
+    cookiecutter(template, checkout, no_input, rc_file=rc_file, extra_globals=dict(
         checkout=checkout,
         verbose=verbose,
     ))

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -67,4 +67,7 @@ def main(template, no_input, checkout, verbose):
             level=logging.INFO
         )
 
-    cookiecutter(template, checkout, no_input)
+    cookiecutter(template, checkout, no_input, extra_globals=dict(
+        checkout=checkout,
+        verbose=verbose,
+    ))

--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -27,6 +27,9 @@ DEFAULT_CONFIG = {
     'default_context': {}
 }
 
+# TODO: test on windows...
+USER_CONFIG_PATH = '~/.cookiecutterrc'
+
 
 def get_config(config_path):
     """
@@ -50,15 +53,15 @@ def get_config(config_path):
     return config_dict
 
 
-def get_user_config():
+def get_user_config(rc_file=USER_CONFIG_PATH):
     """
-    Retrieve config from the user's ~/.cookiecutterrc, if it exists.
-    Otherwise, return None.
+    Retrieve config from the given path, if it exists.
+    Otherwise, return a deep copy of the defaults.
+
+    :param rc_file: Path to the user configuration file
     """
-
-    # TODO: test on windows...
-    USER_CONFIG_PATH = os.path.expanduser('~/.cookiecutterrc')
-
-    if os.path.exists(USER_CONFIG_PATH):
-        return get_config(USER_CONFIG_PATH)
-    return copy.copy(DEFAULT_CONFIG)
+    rc_file = os.path.expanduser(rc_file or '')
+    if rc_file and os.path.exists(rc_file):
+        return get_config(rc_file)
+    else:
+        return copy.copy(DEFAULT_CONFIG)

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -17,7 +17,7 @@ import os
 from datetime import datetime
 
 from . import __version__ as cookiecutter_version
-from .config import get_user_config
+from .config import get_user_config, USER_CONFIG_PATH
 from .prompt import prompt_for_config
 from .generate import generate_context, generate_files
 from .vcs import clone
@@ -56,7 +56,7 @@ def expand_abbreviations(template, config_dict):
 
 
 def cookiecutter(template, checkout=None, no_input=False, extra_context=None,
-                 extra_globals=None):
+                 extra_globals=None, rc_file=USER_CONFIG_PATH):
     """
     API equivalent to using Cookiecutter at the command line.
 
@@ -68,11 +68,12 @@ def cookiecutter(template, checkout=None, no_input=False, extra_context=None,
         and user configuration.
     :param extra_globals: A dictionary of values added to the Jinja2 context,
         e.g. custom filters.
+    :param rc_file: Path to the user configuration file
     """
 
     # Get user config from ~/.cookiecutterrc or equivalent
     # If no config file, sensible defaults from config.DEFAULT_CONFIG are used
-    config_dict = get_user_config()
+    config_dict = get_user_config(rc_file)
 
     template = expand_abbreviations(template, config_dict)
 

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -53,7 +53,8 @@ def expand_abbreviations(template, config_dict):
     return template
 
 
-def cookiecutter(template, checkout=None, no_input=False, extra_context=None, extra_globals=None):
+def cookiecutter(template, checkout=None, no_input=False, extra_context=None,
+                 extra_globals=None):
     """
     API equivalent to using Cookiecutter at the command line.
 

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -15,6 +15,7 @@ from __future__ import unicode_literals
 import logging
 import os
 
+from . import __version__ as cookiecutter_version
 from .config import get_user_config
 from .prompt import prompt_for_config
 from .generate import generate_context, generate_files
@@ -95,6 +96,13 @@ def cookiecutter(template, checkout=None, no_input=False, extra_context=None):
     # prompt the user to manually configure at the command line.
     # except when 'no-input' flag is set
     context['cookiecutter'] = prompt_for_config(context, no_input)
+
+    # Add some system values, especially for use by hook scripts
+    context.update(dict(
+        version=cookiecutter_version,
+        repo_dir=repo_dir,
+        context_file=context_file,
+    ))
 
     # Create project from local context and project template.
     generate_files(

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -53,7 +53,7 @@ def expand_abbreviations(template, config_dict):
     return template
 
 
-def cookiecutter(template, checkout=None, no_input=False, extra_context=None):
+def cookiecutter(template, checkout=None, no_input=False, extra_context=None, extra_globals=None):
     """
     API equivalent to using Cookiecutter at the command line.
 
@@ -63,6 +63,8 @@ def cookiecutter(template, checkout=None, no_input=False, extra_context=None):
     :param no_input: Prompt the user at command line for manual configuration?
     :param extra_context: A dictionary of context that overrides default
         and user configuration.
+    :param extra_globals: A dictionary of values added to the Jinja2 context,
+        e.g. custom filters.
     """
 
     # Get user config from ~/.cookiecutterrc or equivalent
@@ -98,6 +100,7 @@ def cookiecutter(template, checkout=None, no_input=False, extra_context=None):
     context['cookiecutter'] = prompt_for_config(context, no_input)
 
     # Add some system values, especially for use by hook scripts
+    context.update(extra_globals or {})
     context.update(dict(
         version=cookiecutter_version,
         repo_dir=repo_dir,

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -107,8 +107,8 @@ def cookiecutter(template, checkout=None, no_input=False, extra_context=None,
     context.update(extra_globals or {})
     context.update(dict(
         version=cookiecutter_version,
-        repo_dir=repo_dir,
-        context_file=context_file,
+        repo_dir=os.path.abspath(repo_dir),
+        context_file=os.path.abspath(context_file),
         current_year=now.year,
         current_date=now.ctime(),
         current_date_iso=now.isoformat(b' ' if not PY3 else u' '),

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -14,12 +14,14 @@ library rather than a script.
 from __future__ import unicode_literals
 import logging
 import os
+from datetime import datetime
 
 from . import __version__ as cookiecutter_version
 from .config import get_user_config
 from .prompt import prompt_for_config
 from .generate import generate_context, generate_files
 from .vcs import clone
+from .compat import PY3
 
 logger = logging.getLogger(__name__)
 
@@ -101,11 +103,15 @@ def cookiecutter(template, checkout=None, no_input=False, extra_context=None,
     context['cookiecutter'] = prompt_for_config(context, no_input)
 
     # Add some system values, especially for use by hook scripts
+    now = datetime.now()
     context.update(extra_globals or {})
     context.update(dict(
         version=cookiecutter_version,
         repo_dir=repo_dir,
         context_file=context_file,
+        current_year=now.year,
+        current_date=now.ctime(),
+        current_date_iso=now.isoformat(b' ' if not PY3 else u' '),
     ))
 
     # Create project from local context and project template.

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -68,6 +68,14 @@ Possible settings are:
   The `gh` (github) and `bb` (bitbucket) abbreviations shown above are actually
   built in, and can be used without defining them yourself.
 
+The default location ``~/.cookiecutterrc`` can be changed by using the
+``--rc-file`` command line option (1.1.0+). Passing an empty value will prevent
+the loading of user settings altogether and use the defaults instead. This is
+useful when writing integration tests for your own cookiecutters, since then
+you have no interference from the user account you run them in. Also, if you
+work with many different profiles under one user account (like in a CI server),
+the ability to load a specific one can come in handy.
+
 Calling Cookiecutter Functions From Python
 ------------------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+binaryornot>=0.2.0
+jinja2>=2.7
+PyYAML>=3.10
+click<4.0

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ class PyTest(Command):
         sys.exit(errno)
 
 
-setup(
+project = dict(
     name='cookiecutter',
     version=version,
     description=('A command-line utility that creates projects from project '
@@ -104,3 +104,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements
 )
+
+if __name__ == '__main__':
+    setup(**project)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from distutils.core import setup, Command
 
-version = "1.0.0"
+version = "1.0.1"
 
 if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')

--- a/tests/test_get_user_config.py
+++ b/tests/test_get_user_config.py
@@ -18,6 +18,16 @@ import pytest
 from cookiecutter import config
 from cookiecutter.exceptions import InvalidConfiguration
 
+VALID_CONFIG_PATH = 'tests/test-config/valid-config.yaml'
+VALID_CONFIG = {
+    'cookiecutters_dir': '/home/example/some-path-to-templates',
+    'default_context': {
+        'full_name': 'Firstname Lastname',
+        'email': 'firstname.lastname@gmail.com',
+        'github_username': 'example'
+    }
+}
+
 
 @pytest.fixture(scope='module')
 def user_config_path():
@@ -63,17 +73,28 @@ def test_get_user_config_valid(user_config_path):
     """
     Get config from a valid ~/.cookiecutterrc file
     """
-    shutil.copy('tests/test-config/valid-config.yaml', user_config_path)
+    shutil.copy(VALID_CONFIG_PATH, user_config_path)
     conf = config.get_user_config()
-    expected_conf = {
-        'cookiecutters_dir': '/home/example/some-path-to-templates',
-        'default_context': {
-            'full_name': 'Firstname Lastname',
-            'email': 'firstname.lastname@gmail.com',
-            'github_username': 'example'
-        }
-    }
-    assert conf == expected_conf
+    assert conf == VALID_CONFIG
+
+
+def test_get_user_config_from_path():
+    """
+    Get config from a valid ~/.cookiecutterrc file directly
+    """
+    conf = config.get_user_config(VALID_CONFIG_PATH)
+    assert conf == VALID_CONFIG
+
+
+@pytest.mark.usefixtures('back_up_rc')
+def test_get_user_config_no_rc(user_config_path):
+    """
+    Do NOT get config from a valid ~/.cookiecutterrc file
+    """
+    shutil.copy(VALID_CONFIG_PATH, user_config_path)
+    for rc_file in (None, '', 'this-will-not-ever-exist'):
+        conf = config.get_user_config(rc_file)
+        assert conf == config.DEFAULT_CONFIG
 
 
 @pytest.mark.usefixtures('back_up_rc')


### PR DESCRIPTION
You can find the use-case for this [here](https://github.com/Springerle/dh-virtualenv-mold/blob/master/hooks/pre_gen_project.py). It passes information to hooks (and any template) that is either hard to get or unavailable to them right now. If you agree this should be merged, I can add documentation and tests to this PR.

Sample output (with v1.0.0):

```
*** verbose=None
*** checkout=None
*** version=None
*** version_info=()
*** repo_dir=None
*** context_file=None
*** context={u'year': u'2015', …
…
```

Sample output (with patch):

```
*** verbose=False
*** checkout=None
*** version=1.0.0
*** version_info=(1, 0, 0)
*** repo_dir=/home/jhe/src/dh-virtualenv-mold
*** context_file=/home/jhe/src/dh-virtualenv-mold/cookiecutter.json
*** context={u'year': u'2015', …}
*** context[pprint]={u'distro': u'UNRELEASED',
…
u'year': u'2015'}
*** argv=['/tmp/tmpo5TZB5.py']
*** cwd=/home/jhe/src/gh-commander/debian
*** ls=['rules', 'changelog', 'pyvenv-foobar.links', 'control', 'copyright', 'pyvenv-foobar.triggers', 'compat', 'pyvenv-foobar.postinst']
```
