### PR TITLE
Remove 2.6 support from setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,16 @@ if sys.argv[-1] == 'tag':
 readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
-requirements = ['binaryornot>=0.2.0', 'jinja2>=2.7', 'PyYAML>=3.10', 'click<4.0']
-test_requirements = ['pytest']
+requirements = [
+    'binaryornot>=0.2.0',
+    'jinja2>=2.7',
+    'PyYAML>=3.10',
+    'click<4.0'
+]
+
+test_requirements = [
+    'pytest'
+]
 
 # Add Python 2.7-specific dependencies
 if sys.version < '3':

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 requirements = ['binaryornot>=0.2.0', 'jinja2>=2.7', 'PyYAML>=3.10', 'click<4.0']
 test_requirements = ['pytest']
 
-# Add Python 2.6 and 2.7-specific dependencies
+# Add Python 2.7-specific dependencies
 if sys.version < '3':
     requirements.append('mock')
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ if sys.argv[-1] == 'readme':
     print(long_description)
     sys.exit()
 
+
 class PyTest(Command):
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
 
@@ -65,8 +66,8 @@ setup(
     name='cookiecutter',
     version=version,
     description=('A command-line utility that creates projects from project '
-                 'templates, e.g. creating a Python package project from a Python '
-                 'package project template.'),
+                 'templates, e.g. creating a Python package project from a '
+                 'Python package project template.'),
     long_description=long_description,
     author='Audrey Roy',
     author_email='audreyr@gmail.com',
@@ -100,8 +101,11 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development',
     ],
-    keywords='cookiecutter, Python, projects, project templates, Jinja2, \
-        skeleton, scaffolding, project directory, setup.py, package, packaging',
+    keywords=(
+        'cookiecutter, Python, projects, project templates, Jinja2, '
+        'skeleton, scaffolding, project directory, setup.py, package, '
+        'packaging'
+    ),
     cmdclass = {'test': PyTest},
     test_suite='tests',
     tests_require=test_requirements

--- a/setup.py
+++ b/setup.py
@@ -26,12 +26,6 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 requirements = ['binaryornot>=0.2.0', 'jinja2>=2.7', 'PyYAML>=3.10', 'click<4.0']
 test_requirements = ['pytest']
 
-# Add Python 2.6-specific dependencies
-if sys.version_info[:2] < (2, 7):
-    requirements.append('ordereddict')
-    requirements.append('simplejson')
-    test_requirements.append('unittest2')
-
 # Add Python 2.6 and 2.7-specific dependencies
 if sys.version < '3':
     requirements.append('mock')


### PR DESCRIPTION
Found some leftover code in `setup.py` that specifically targets Python 2.6 which is not supported any longer :construction_worker: 