### PR TITLE
Remove python 26 support from docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Did someone say features?
 
 * Cross-platform: Windows, Mac, and Linux are officially supported.
 
-* Works with Python 2.6, 2.7, 3.3, 3.4, and PyPy. *(But you don't have to know/write Python
+* Works with Python 2.7, 3.3, 3.4, and PyPy. *(But you don't have to know/write Python
   code to use Cookiecutter.)*
 
 * Project templates can be in any programming language or markup format:

--- a/docs/contributor_guidelines.rst
+++ b/docs/contributor_guidelines.rst
@@ -10,7 +10,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.3, and PyPy on Appveyor and Travis CI.
+3. The pull request should work for Python 2.7, 3.3, and PyPy on Appveyor and Travis CI.
 4. Check https://travis-ci.org/audreyr/cookiecutter/pull_requests and 
    https://ci.appveyor.com/project/audreyr/cookiecutter/history to ensure the tests pass for all supported Python versions and platforms.
 

--- a/docs/contributor_guidelines.rst
+++ b/docs/contributor_guidelines.rst
@@ -10,7 +10,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.3, and PyPy on Appveyor and Travis CI.
+3. The pull request should work for Python 2.7, 3.3, 3.4, and PyPy on Appveyor and Travis CI.
 4. Check https://travis-ci.org/audreyr/cookiecutter/pull_requests and 
    https://ci.appveyor.com/project/audreyr/cookiecutter/history to ensure the tests pass for all supported Python versions and platforms.
 


### PR DESCRIPTION
I noticed that the latest docs still promise **Python 2.6** support.

This PR changes the readme as well as the contributor guidelines accordingly.

Additionally it adds **Python 3.4** to the pull request guidelines.