### PR TITLE
tests: ensure to use an existing command to test `which`

### DIFF
--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -12,7 +12,7 @@ from cookiecutter.compat import which
 
 
 def test_existing_command():
-    assert which('cookiecutter')
+    assert which('date')
 
 
 def test_non_existing_command():


### PR DESCRIPTION
When testing cookiecutter while not having it installed, we get this
failure:

    =================================== FAILURES ===================================
    ____________________________ test_existing_command _____________________________

        def test_existing_command():
    >       assert which('cookiecutter')
    E       assert None
    E        +  where None = which('cookiecutter')

    tests/test_compat.py:15: AssertionError
    =============== 1 failed, 74 passed, 16 skipped in 0.43 seconds ================

A command that is almost guaranteed to exist is `date` (both on Unix and
Windows systems).