### PR TITLE
cli: allow `python -m cookieclutter.cli` invocation

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -73,3 +73,6 @@ def main(template, no_input, checkout, verbose):
     except OutputDirExistsException as e:
         click.echo(e)
         sys.exit(1)
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
Without even installing cookiecutter, a user can run it with `python -m
cookieclutter.cli`.

Another option would be to allow `python -m cookieclutter` directly.