### PR TITLE
output_dir for python API invocation + parametrize output_dir tests

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -52,7 +52,8 @@ def expand_abbreviations(template, config_dict):
     return template
 
 
-def cookiecutter(template, checkout=None, no_input=False, extra_context=None):
+def cookiecutter(template, checkout=None, no_input=False, extra_context=None,
+                 output_dir='.'):
     """
     API equivalent to using Cookiecutter at the command line.
 
@@ -62,6 +63,7 @@ def cookiecutter(template, checkout=None, no_input=False, extra_context=None):
     :param no_input: Prompt the user at command line for manual configuration?
     :param extra_context: A dictionary of context that overrides default
         and user configuration.
+    :param output_dir: Where to output the generated project dir into.
     """
 
     # Get user config from ~/.cookiecutterrc or equivalent
@@ -99,5 +101,6 @@ def cookiecutter(template, checkout=None, no_input=False, extra_context=None):
     # Create project from local context and project template.
     generate_files(
         repo_dir=repo_dir,
-        context=context
+        context=context,
+        output_dir=output_dir
     )

--- a/tests/test_output_folder.py
+++ b/tests/test_output_folder.py
@@ -15,6 +15,7 @@ import pytest
 
 from cookiecutter import generate
 from cookiecutter import utils
+from cookiecutter.main import cookiecutter as _cookiecutter
 
 
 @pytest.fixture(scope='function')
@@ -29,24 +30,74 @@ def remove_output_folder(request):
 
 
 @pytest.mark.usefixtures('clean_system', 'remove_output_folder')
-def test_output_folder():
+@pytest.mark.parametrize("output_dir", [None, '.', 'output_folder/somewhere_else'])
+def test_output_folder(output_dir):
     context = generate.generate_context(
         context_file='tests/test-output-folder/cookiecutter.json'
     )
-    generate.generate_files(
-        context=context,
-        repo_dir='tests/test-output-folder'
-    )
+
+    params = {
+        "context": context,
+        "repo_dir": 'tests/test-output-folder'
+    }
+
+    # test without, default, '.' catch regressions method sig is refactored
+    if output_dir:
+        params['output_dir'] = output_dir
+
+    generate.generate_files(**params)
+
+    prefix = output_dir if output_dir else ""
 
     something = """Hi!
 My name is Audrey Greenfeld.
 It is 2014."""
-    something2 = open('output_folder/something.txt').read()
+    something2 = open(os.path.join(prefix,'output_folder/something.txt')).read()
     assert something == something2
 
     in_folder = "The color is green and the letter is D."
-    in_folder2 = open('output_folder/folder/in_folder.txt').read()
+    in_folder2 = open(
+        os.path.join(prefix, 'output_folder/folder/in_folder.txt')
+    ).read()
     assert in_folder == in_folder2
 
-    assert os.path.isdir('output_folder/im_a.dir')
-    assert os.path.isfile('output_folder/im_a.dir/im_a.file.py')
+    assert os.path.isdir(
+        os.path.join(prefix, 'output_folder/im_a.dir')
+    )
+    assert os.path.isfile(
+        os.path.join(prefix, 'output_folder/im_a.dir/im_a.file.py')
+    )
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_output_folder')
+@pytest.mark.parametrize("output_dir", [None, '.', 'output_folder/somewhere_else'])
+def test_cookiecutter_output_folder(output_dir):
+
+    # test without, default, '.' catch regressions method sig is refactored
+    params = {}
+
+    if output_dir:
+        params['output_dir'] = output_dir
+
+    _cookiecutter('tests/test-output-folder', no_input=True, **params)
+
+    prefix = output_dir if output_dir else ""
+
+    something = """Hi!
+My name is Audrey Greenfeld.
+It is 2014."""
+    something2 = open(os.path.join(prefix,'output_folder/something.txt')).read()
+    assert something == something2
+
+    in_folder = "The color is green and the letter is D."
+    in_folder2 = open(
+        os.path.join(prefix, 'output_folder/folder/in_folder.txt')
+    ).read()
+    assert in_folder == in_folder2
+
+    assert os.path.isdir(
+        os.path.join(prefix, 'output_folder/im_a.dir')
+    )
+    assert os.path.isfile(
+        os.path.join(prefix, 'output_folder/im_a.dir/im_a.file.py')
+    )


### PR DESCRIPTION
Need this for a cookiecutter project that's tested using [python api](http://cookiecutter.readthedocs.org/en/latest/advanced_usage.html#calling-cookiecutter-functions-from-python).

Also parametrize output_dir tests and add testcase for cookiecutter python object.