### PR TITLE
Fix encoding for latest tox

### DIFF
--- a/tests/test_preferred_encoding.py
+++ b/tests/test_preferred_encoding.py
@@ -6,6 +6,7 @@ import pytest
 
 from cookiecutter.compat import PY3
 
+
 @pytest.mark.skipif(not PY3, reason='Only necessary on Python3')
 def test_not_ascii():
     """Make sure that the systems preferred encoding is not `ascii`.

--- a/tests/test_preferred_encoding.py
+++ b/tests/test_preferred_encoding.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+import locale
+import codecs
+
+
+def test_not_ascii():
+    """Make sure that the systems preferred encoding is not `ascii`.
+
+    Otherwise `click` is raising a RuntimeError for Python3. For a detailed
+    description of this very problem please consult the following gist:
+    https://gist.github.com/hackebrot/937245251887197ef542
+
+    This test also checks that `tox.ini` explicitly copies the according
+    system environment variables to the test environments.
+    """
+    try:
+        preferred_encoding = locale.getpreferredencoding()
+        fs_enc = codecs.lookup(preferred_encoding).name
+    except Exception:
+        fs_enc = 'ascii'
+    assert fs_enc != 'ascii'

--- a/tests/test_preferred_encoding.py
+++ b/tests/test_preferred_encoding.py
@@ -2,8 +2,11 @@
 
 import locale
 import codecs
+import pytest
 
+from cookiecutter.compat import PY3
 
+@pytest.mark.skipif(not PY3, reason='Only necessary on Python3')
 def test_not_ascii():
     """Make sure that the systems preferred encoding is not `ascii`.
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py27, py33, py34, pypy, flake8
 
 [testenv]
+passenv = LC_ALL, LANG
 commands = py.test --cov cookiecutter {posargs:tests}
 deps = pytest
        pytest-cov


### PR DESCRIPTION
This PR solves a problem with our setup of ``tox`` and ``click`` which is explained in great detail over https://gist.github.com/hackebrot/937245251887197ef542

I implement a simple test for PY3 to make sure we keep the new setting in ``tox.ini`` that comes with this PR. If anyone ever experiences a similar problem with our setup, we should have a good starting point to investigate, I think.

Tests are passing now on Mac OS X as well as Ubuntu Trusty Tahr.

Many thanks to @audreyr @pydanny @goodwillcoding and @ionelmc who eventually pointed me into the right direction. :bow: 