### PR TITLE
Provide `cookiecutter._now` for config templates

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -10,6 +10,7 @@ Functions for prompting the user for project info.
 
 from __future__ import unicode_literals
 from collections import OrderedDict
+import datetime
 
 import click
 
@@ -108,7 +109,9 @@ def prompt_for_config(context, no_input=False):
 
     :param no_input: Prompt the user at command line for manual configuration?
     """
-    cookiecutter_dict = {}
+    cookiecutter_dict = {
+        '_now': datetime.datetime.today()
+    }
     env = Environment()
 
     for key, raw in iteritems(context['cookiecutter']):


### PR DESCRIPTION
This allows to use the following (in the cookiecutter-django template):

    -    "now": "2015/01/13",
    -    "year": "{{ cookiecutter.now[:4] }}",
    +    "year": "{{ cookiecutter._now.strftime('%Y-%m-%d') }}",

Using a datetime object (instead of a formatted string) makes it more
flexible for different use cases.

This addresses #154 and #155 (which I've found after doing this patch).

Using the approach from #155 might be better (providing `strftime`).
It is mentioned in the docs: https://cookiecutter.readthedocs.org/en/latest/advanced_usage.html#example-injecting-a-timestamp