### PR TITLE
[Issue 470] Error out if project output directory exists.

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -18,6 +18,7 @@ import click
 
 from cookiecutter import __version__
 from cookiecutter.main import cookiecutter
+from cookiecutter.exceptions import OutputDirExistsException
 
 logger = logging.getLogger(__name__)
 
@@ -67,4 +68,8 @@ def main(template, no_input, checkout, verbose):
             level=logging.INFO
         )
 
-    cookiecutter(template, checkout, no_input)
+    try:
+        cookiecutter(template, checkout, no_input)
+    except OutputDirExistsException as e:
+        click.echo(e)
+        sys.exit(1)

--- a/cookiecutter/exceptions.py
+++ b/cookiecutter/exceptions.py
@@ -68,3 +68,9 @@ class ContextDecodingException(CookiecutterException):
     """
     Raised when a project's JSON context file can not be decoded.
     """
+
+
+class OutputDirExistsException(CookiecutterException):
+    """
+    Raised when the output directory of the project exists already.
+    """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,32 @@
 import os
+import pytest
 
 from click.testing import CliRunner
 
 from cookiecutter.cli import main
+from cookiecutter import utils
 
 runner = CliRunner()
+
+
+@pytest.fixture
+def remove_fake_project_dir(request):
+    """
+    Remove the fake project directory created during the tests.
+    """
+    def fin_remove_fake_project_dir():
+        if os.path.isdir('fake-project'):
+            utils.rmtree('fake-project')
+    request.addfinalizer(fin_remove_fake_project_dir)
+
+
+@pytest.fixture
+def make_fake_project_dir(request):
+    """
+    Create the fake project directory created during the tests.
+    """
+    if not os.path.isdir('fake-project'):
+        os.makedirs('fake-project')
 
 
 def test_cli_version():
@@ -13,12 +35,22 @@ def test_cli_version():
     assert result.output.startswith('Cookiecutter')
 
 
+@pytest.mark.usefixtures('make_fake_project_dir', 'remove_fake_project_dir')
+def test_cli_error_on_existing_output_directory():
+    result = runner.invoke(main, ['tests/fake-repo-pre/', '--no-input'])
+    assert result.exit_code != 0
+    expected_error_msg = 'Error: "fake-project" directory already exists\n'
+    assert result.output == expected_error_msg
+
+
+@pytest.mark.usefixtures('remove_fake_project_dir')
 def test_cli():
     result = runner.invoke(main, ['tests/fake-repo-pre/', '--no-input'])
     assert result.exit_code == 0
     assert os.path.isdir('fake-project')
 
 
+@pytest.mark.usefixtures('remove_fake_project_dir')
 def test_cli_verbose():
     result = runner.invoke(main, ['tests/fake-repo-pre/', '--no-input', '-v'])
     assert result.exit_code == 0

--- a/tests/test_output_folder.py
+++ b/tests/test_output_folder.py
@@ -15,6 +15,7 @@ import pytest
 
 from cookiecutter import generate
 from cookiecutter import utils
+from cookiecutter import exceptions
 
 
 @pytest.fixture(scope='function')
@@ -50,3 +51,19 @@ It is 2014."""
 
     assert os.path.isdir('output_folder/im_a.dir')
     assert os.path.isfile('output_folder/im_a.dir/im_a.file.py')
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_output_folder')
+def test_exception_when_output_folder_exists():
+    context = generate.generate_context(
+        context_file='tests/test-output-folder/cookiecutter.json'
+    )
+    output_folder = context['cookiecutter']['test_name']
+
+    if not os.path.exists(output_folder):
+        os.makedirs(output_folder)
+    with pytest.raises(exceptions.OutputDirExistsException):
+        generate.generate_files(
+            context=context,
+            repo_dir='tests/test-output-folder'
+        )


### PR DESCRIPTION
Fix issue #470 by erroring out if the project output directory
exists. This will prevent cookiecutter from writing into the existing directories like it does now.