### PR TITLE
Remove test command in favor of tox

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -120,7 +120,7 @@ Now you can make your changes locally.
     $ tox -e cov-report
 
 8. Submit a pull request through the GitHub website.
-
+
 Contributor Guidelines
 -----------------------
 
@@ -166,33 +166,26 @@ Coding Standards
 
   * Write new code in Python 3.
 
-Testing
--------
+Testing with tox
+----------------
 
-To run a particular test::
+Tox uses py.test under the hood, hence it supports the same syntax for selecting tests.
 
-    $ python -m unittest tests.test_find.TestFind.test_find_template
+For further information please consult the `pytest usage docs`_.
 
-To run a subset of tests::
+To run a particular test class with tox::
 
-    $ python -m unittest tests.test_find
-
-Testing with py.test
---------------------
-
-To run a particular test class with py.test::
-
-    $ py.test -k TestGetConfig
+    $ tox -e py '-k TestFindHooks'
 
 To run some tests with names matching a string expression::
 
-    $ py.test -k generate
+    $ tox -e py '-k generate'
 
 Will run all tests matching "generate", test_generate_files for example.
 
 To run just one method::
 
-    $ py.test -k TestGetConfig::test_get_config
+    $ tox -e py '-k "TestFindHooks and test_find_hook"'
 
 
 To run all tests using various versions of python in virtualenvs defined in tox.ini, just run tox.::
@@ -219,6 +212,7 @@ Python 3.3 tests fail locally
 Try upgrading Tox to the latest version. I noticed that they were failing
 locally with Tox 1.5 but succeeding when I upgraded to Tox 1.7.1.
 
+.. _`pytest usage docs`: https://pytest.org/latest/usage.html#specifying-tests-selecting-tests
 
 Core Committer Guide
 ====================

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -106,7 +106,7 @@ Now you can make your changes locally.
 5. When you're done making changes, check that your changes pass the tests and flake8::
 
     $ flake8 cookiecutter tests
-    $ python setup.py test
+    $ pip install tox
     $ tox
 
 6. Commit your changes and push your branch to GitHub::
@@ -117,11 +117,10 @@ Now you can make your changes locally.
 
 7. Check that the test coverage hasn't dropped::
 
-    coverage run --source cookiecutter setup.py test
-    coverage report -m
-    coverage html
+    $ tox -e cov-report
 
-8. Submit a pull request through the GitHub website.
+8. Submit a pull request through the GitHub website.
+
 Contributor Guidelines
 -----------------------
 
@@ -134,7 +133,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.3, and PyPy on Appveyor and Travis CI.
+3. The pull request should work for Python 2.7, 3.3, 3.4, and PyPy on Appveyor and Travis CI.
 4. Check https://travis-ci.org/audreyr/cookiecutter/pull_requests and 
    https://ci.appveyor.com/project/audreyr/cookiecutter/history to ensure the tests pass for all supported Python versions and platforms.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -105,9 +105,14 @@ Now you can make your changes locally.
 
 5. When you're done making changes, check that your changes pass the tests and flake8::
 
-    $ flake8 cookiecutter tests
     $ pip install tox
     $ tox
+
+Please note that tox runs flake8 automatically, since we have a test environment for it.
+
+If you feel like running only the flake8 environment, please use the following command::
+
+    $ tox -e flake8
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ lint:
 	flake8 cookiecutter tests
 
 test:
-	python setup.py test
+	tox -e py
 
 test-all:
 	tox

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,7 @@ test-all:
 
 
 coverage:
-	coverage run --source cookiecutter setup.py test
-	coverage report -m
-	coverage html
+	tox -e cov-report
 	open htmlcov/index.html
 
 docs:

--- a/cookiecutter/compat.py
+++ b/cookiecutter/compat.py
@@ -8,7 +8,6 @@ OLD_PY2 = sys.version_info[:2] < (2, 7)
 if PY3:  # pragma: no cover
     input_str = 'builtins.input'
     iteritems = lambda d: iter(d.items())
-    from unittest.mock import patch
     from io import StringIO
 
 
@@ -17,7 +16,6 @@ else:  # pragma: no cover
     input = raw_input
     input_str = '__builtin__.raw_input'
     iteritems = lambda d: d.iteritems()
-    from mock import patch
     from cStringIO import StringIO
 
 
@@ -101,4 +99,4 @@ def is_string(obj):
     return isinstance(obj, str if PY3 else basestring)
 
 
-_hush_pyflakes = (patch, StringIO, which)
+_hush_pyflakes = (StringIO, which)

--- a/docs/contributor_setup.rst
+++ b/docs/contributor_setup.rst
@@ -22,9 +22,14 @@ Now you can make your changes locally.
 
 5. When you're done making changes, check that your changes pass the tests and flake8::
 
-    $ flake8 cookiecutter tests
     $ pip install tox
     $ tox
+
+Please note that tox runs flake8 automatically, since we have a test environment for it.
+
+If you feel like running only the flake8 environment, please use the following command::
+
+    $ tox -e flake8
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/docs/contributor_setup.rst
+++ b/docs/contributor_setup.rst
@@ -23,7 +23,7 @@ Now you can make your changes locally.
 5. When you're done making changes, check that your changes pass the tests and flake8::
 
     $ flake8 cookiecutter tests
-    $ python setup.py test
+    $ pip install tox
     $ tox
 
 6. Commit your changes and push your branch to GitHub::
@@ -34,8 +34,6 @@ Now you can make your changes locally.
 
 7. Check that the test coverage hasn't dropped::
 
-    coverage run --source cookiecutter setup.py test
-    coverage report -m
-    coverage html
+    $ tox -e cov-report
 
 8. Submit a pull request through the GitHub website.

--- a/docs/contributor_testing.rst
+++ b/docs/contributor_testing.rst
@@ -1,30 +1,19 @@
-Testing
--------
+Testing with tox
+----------------
 
-To run a particular test::
+To run a particular test class with tox::
 
-    $ python -m unittest tests.test_find.TestFind.test_find_template
-
-To run a subset of tests::
-
-    $ python -m unittest tests.test_find
-
-Testing with py.test
---------------------
-
-To run a particular test class with py.test::
-
-    $ py.test -k TestGetConfig
+    $ tox -e py "-k TestGetConfig"
 
 To run some tests with names matching a string expression::
 
-    $ py.test -k generate
+    $ tox -e py "-k generate"
 
 Will run all tests matching "generate", test_generate_files for example.
 
 To run just one method::
 
-    $ py.test -k TestGetConfig::test_get_config
+    $ tox -e py "-k TestGetConfig::test_get_config"
 
 
 To run all tests using various versions of python in virtualenvs defined in tox.ini, just run tox.::

--- a/docs/contributor_testing.rst
+++ b/docs/contributor_testing.rst
@@ -3,17 +3,17 @@ Testing with tox
 
 To run a particular test class with tox::
 
-    $ tox -e py "-k TestGetConfig"
+    $ tox -e py '-k TestFindHooks'
 
 To run some tests with names matching a string expression::
 
-    $ tox -e py "-k generate"
+    $ tox -e py '-k generate'
 
 Will run all tests matching "generate", test_generate_files for example.
 
 To run just one method::
 
-    $ tox -e py "-k TestGetConfig::test_get_config"
+    $ tox -e py '-k "TestFindHooks and test_find_hook"'
 
 
 To run all tests using various versions of python in virtualenvs defined in tox.ini, just run tox.::

--- a/docs/contributor_testing.rst
+++ b/docs/contributor_testing.rst
@@ -1,6 +1,10 @@
 Testing with tox
 ----------------
 
+Tox uses py.test under the hood, hence it supports the same syntax for selecting tests.
+
+For further information please consult the `pytest usage docs`_.
+
 To run a particular test class with tox::
 
     $ tox -e py '-k TestFindHooks'
@@ -40,3 +44,4 @@ Python 3.3 tests fail locally
 Try upgrading Tox to the latest version. I noticed that they were failing
 locally with Tox 1.5 but succeeding when I upgraded to Tox 1.7.1.
 
+.. _`pytest usage docs`: https://pytest.org/latest/usage.html#specifying-tests-selecting-tests

--- a/setup.py
+++ b/setup.py
@@ -37,12 +37,6 @@ test_requirements = [
     'pytest'
 ]
 
-# Add Python 2.7-specific dependencies
-if sys.version < '3':
-    requirements.append('mock')
-
-# There are no Python 3-specific dependencies to add
-
 long_description = readme + '\n\n' + history
 
 if sys.argv[-1] == 'readme':

--- a/setup.py
+++ b/setup.py
@@ -50,21 +50,6 @@ if sys.argv[-1] == 'readme':
     sys.exit()
 
 
-class PyTest(Command):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        self.pytest_args = []
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
-
-
 setup(
     name='cookiecutter',
     version=version,
@@ -109,7 +94,4 @@ setup(
         'skeleton, scaffolding, project directory, setup.py, package, '
         'packaging'
     ),
-    cmdclass = {'test': PyTest},
-    test_suite='tests',
-    tests_require=test_requirements
 )

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,6 @@ requirements = [
     'click<5.0'
 ]
 
-test_requirements = [
-    'pytest'
-]
-
 long_description = readme + '\n\n' + history
 
 if sys.argv[-1] == 'readme':

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ import os
 import sys
 
 try:
-    from setuptools import setup, Command
+    from setuptools import setup
 except ImportError:
-    from distutils.core import setup, Command
+    from distutils.core import setup
 
 version = "1.0.0"
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27, py33, py34, pypy, flake8
 
 [testenv]
 passenv = LC_ALL, LANG
-commands = py.test --cov cookiecutter {posargs:tests}
+commands = py.test --cov=cookiecutter {posargs:tests}
 deps = pytest
        pytest-cov
        pytest-mock

--- a/tox.ini
+++ b/tox.ini
@@ -9,14 +9,12 @@ deps = pytest
        pytest-mock
 
 [testenv:py27]
-deps =
-    {[testenv]deps}
-    mock
+deps = {[testenv]deps}
+       mock
 
 [testenv:pypy]
-deps =
-    {[testenv]deps}
-    mock
+deps = {[testenv]deps}
+       mock
 
 [testenv:flake8]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,6 @@ deps =
     pep8==1.6.2
 commands =
     flake8 cookiecutter
+
+[testenv:cov-report]
+commands = py.test --cov=cookiecutter --cov-report=term --cov-report=html

--- a/tox.ini
+++ b/tox.ini
@@ -8,12 +8,6 @@ deps = pytest
        pytest-cov
        pytest-mock
 
-[testenv:py27]
-deps = {[testenv]deps}
-
-[testenv:pypy]
-deps = {[testenv]deps}
-
 [testenv:flake8]
 deps =
     flake8==2.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,9 @@ deps = pytest
 
 [testenv:py27]
 deps = {[testenv]deps}
-       mock
 
 [testenv:pypy]
 deps = {[testenv]deps}
-       mock
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
This PR introduces a better way of running the test suite. Instead of setting up a `TestCommand` in `setup.py` it leaves the dependency management for testing to `tox`. As a consequence I also removed `mock` from `compat.py` and `setup.py`. From what I know, it was solely used in tests (and `grep` did not report anything else).

The steps to run the test suite are as follows:

```bash
$ git clone https://github.com/audreyr/cookiecutter.git
$ cd cookiecutter/
$ mkvirtualenv -a $(pwd) cookiecutter
$ python setup.py develop

$ pip install tox
$ tox
```

I updated the contributor docs to reflect this behavior, which fixes #466.

Please let me know your thoughts!

Best
Raphael