### PR TITLE
Disable sudo in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # Config file for automatic testing at travis-ci.org
 
+sudo: false
 language: python
 python: 2.7
 env:


### PR DESCRIPTION
Looking into the travis logs I saw a hint, that we are running on a legacy infrastructure. This PR should enable the new travis features according to the doc below:

http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade