### PR TITLE
Fix flake8 in tests dir

### DIFF
--- a/tests/test-output-folder/{{cookiecutter.test_name}}/{{cookiecutter.folder_name}}/{{cookiecutter.filename}}.py
+++ b/tests/test-output-folder/{{cookiecutter.test_name}}/{{cookiecutter.folder_name}}/{{cookiecutter.filename}}.py
@@ -1,2 +1,1 @@
 print("This is the contents of {{ cookiecutter.filename }}.py.")
-

--- a/tests/test-pyhooks/hooks/post_gen_project.py
+++ b/tests/test-pyhooks/hooks/post_gen_project.py
@@ -5,4 +5,3 @@ from __future__ import print_function
 print('pre generation hook')
 f = open('python_post.txt', 'w')
 f.close()
-

--- a/tests/test-pyhooks/hooks/pre_gen_project.py
+++ b/tests/test-pyhooks/hooks/pre_gen_project.py
@@ -5,4 +5,3 @@ from __future__ import print_function
 print('pre generation hook')
 f = open('python_pre.txt', 'w')
 f.close()
-

--- a/tests/test-pyshellhooks/hooks/post_gen_project.py
+++ b/tests/test-pyshellhooks/hooks/post_gen_project.py
@@ -5,4 +5,3 @@ from __future__ import print_function
 print('pre generation hook')
 f = open('python_post.txt', 'w')
 f.close()
-

--- a/tests/test-pyshellhooks/hooks/pre_gen_project.py
+++ b/tests/test-pyshellhooks/hooks/pre_gen_project.py
@@ -5,4 +5,3 @@ from __future__ import print_function
 print('pre generation hook')
 f = open('python_pre.txt', 'w')
 f.close()
-

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -80,12 +80,20 @@ def test_generate_context(input_params, expected_context):
 @pytest.mark.usefixtures('clean_system')
 def test_generate_context_with_json_decoding_error():
     with pytest.raises(ContextDecodingException) as excinfo:
-        generate.generate_context('tests/test-generate-context/invalid-syntax.json')
+        generate.generate_context(
+            'tests/test-generate-context/invalid-syntax.json'
+        )
     # original message from json module should be included
-    assert re.search('Expecting \'{0,1}:\'{0,1} delimiter: line 1 column (19|20) \(char 19\)',
-                     str(excinfo.value))
-    # File name should be included too...for testing purposes, just test the last part of the file.
-    # If we wanted to test the absolute path, we'd have to do some additional work in the test which
-    # doesn't seem that needed at this point.
-    path = os.path.sep.join(['tests', 'test-generate-context', 'invalid-syntax.json'])
+    pattern = (
+        'Expecting \'{0,1}:\'{0,1} delimiter: '
+        'line 1 column (19|20) \(char 19\)'
+    )
+    assert re.search(pattern, str(excinfo.value))
+    # File name should be included too...for testing purposes, just test the
+    # last part of the file. If we wanted to test the absolute path, we'd have
+    # to do some additional work in the test which doesn't seem that needed at
+    # this point.
+    path = os.path.sep.join(
+        ['tests', 'test-generate-context', 'invalid-syntax.json']
+    )
     assert path in str(excinfo.value)


### PR DESCRIPTION
This PR fixes all of the `flake8` issues that I discovered while working on #480.

Once we got both merged, I will enable `flake8` checks for the tests dir in addition to the `cookiecutter` package in `tox.ini`. :triumph: 

cc @michaeljoseph 