### PR TITLE
Implement tests for identify_repo

### DIFF
--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -115,3 +115,18 @@ def test_vcs_not_installed(monkeypatch):
 ])
 def test_identify_known_repo(repo_url, exp_repo_type, exp_repo_url):
     assert vcs.identify_repo(repo_url) == (exp_repo_type, exp_repo_url)
+
+
+@pytest.fixture(params=[
+    "foo+git",  # uses explicit identifier with 'git' in the wrong place
+    "foo+hg",  # uses explicit identifier with 'hg' in the wrong place
+    "foo+bar",  # uses explicit identifier with neither 'git' nor 'hg'
+    "foobar"  # no identifier but neither 'git' nor 'bitbucket' in url
+])
+def unknown_repo_type_url(request):
+    return request.param
+
+
+def test_identify_raise_on_unknown_repo(unknown_repo_type_url):
+    with pytest.raises(exceptions.UnknownRepoType):
+        vcs.identify_repo(unknown_repo_type_url)

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -92,3 +92,26 @@ def test_vcs_not_installed(monkeypatch):
     )
     with pytest.raises(exceptions.VCSNotInstalled):
         vcs.clone('http://norepotypespecified.com')
+
+
+@pytest.mark.parametrize('repo_url, exp_repo_type, exp_repo_url', [
+    (
+        "git+https://github.com/pytest-dev/cookiecutter-pytest-plugin.git",
+        "git",
+        "https://github.com/pytest-dev/cookiecutter-pytest-plugin.git"
+    ), (
+        "hg+https://bitbucket.org/foo/bar.hg",
+        "hg",
+        "https://bitbucket.org/foo/bar.hg"
+    ), (
+        "https://github.com/pytest-dev/cookiecutter-pytest-plugin.git",
+        "git",
+        "https://github.com/pytest-dev/cookiecutter-pytest-plugin.git"
+    ), (
+        "https://bitbucket.org/foo/bar.hg",
+        "hg",
+        "https://bitbucket.org/foo/bar.hg"
+    )
+])
+def test_identify_known_repo(repo_url, exp_repo_type, exp_repo_url):
+    assert vcs.identify_repo(repo_url) == (exp_repo_type, exp_repo_url)


### PR DESCRIPTION
This PR adds tests to cover `vcs.identify_repo`.

I think we should try to come up with a better solution rather than simple string analysis to detect repo types in the long run though. Any ideas? We could at least have a regex that validates if we are dealing with a **valid** bitbucket or github link.

For instance:

```bash
cookiecutter https://gitfoo
```
causes

```bash
...
subprocess.CalledProcessError: Command '[u'git', u'clone', u'https://gitfoo']' returned non-zero exit status 128
```

:worried: 