### PR TITLE
Add tests for cli invocation

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -74,5 +74,5 @@ def main(template, no_input, checkout, verbose):
         click.echo(e)
         sys.exit(1)
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":
     main()

--- a/tests/test_cookiecutter_invocation.py
+++ b/tests/test_cookiecutter_invocation.py
@@ -11,6 +11,7 @@ using the entry point set up for the package.
 import os
 import pytest
 import subprocess
+import sys
 
 from cookiecutter import utils
 
@@ -37,12 +38,15 @@ def project_dir(request):
     return rendered_dir
 
 
-def test_should_invoke_main(project_dir):
+def test_should_invoke_main(monkeypatch, project_dir):
+    monkeypatch.setenv('PYTHONPATH', '.')
+
     subprocess.check_call([
-        'python',
+        sys.executable,
         '-m',
         'cookiecutter.cli',
         'tests/fake-repo-tmpl',
         '--no-input'
     ])
+
     assert os.path.isdir(project_dir)

--- a/tests/test_cookiecutter_invocation.py
+++ b/tests/test_cookiecutter_invocation.py
@@ -8,8 +8,11 @@ Tests to make sure that cookiecutter can be called from the cli without
 using the entry point set up for the package.
 """
 
+import os
 import pytest
 import subprocess
+
+from cookiecutter import utils
 
 
 def test_should_raise_error_without_template_arg(capfd):
@@ -19,3 +22,27 @@ def test_should_raise_error_without_template_arg(capfd):
     _, err = capfd.readouterr()
     exp_message = 'Error: Missing argument "template".'
     assert exp_message in err
+
+
+@pytest.fixture
+def project_dir(request):
+    """Remove the rendered project directory created by the test."""
+    rendered_dir = 'fake-project-templated'
+
+    def remove_generated_project():
+        if os.path.isdir(rendered_dir):
+            utils.rmtree(rendered_dir)
+    request.addfinalizer(remove_generated_project)
+
+    return rendered_dir
+
+
+def test_should_invoke_main(project_dir):
+    subprocess.check_call([
+        'python',
+        '-m',
+        'cookiecutter.cli',
+        'tests/fake-repo-tmpl',
+        '--no-input'
+    ])
+    assert os.path.isdir(project_dir)

--- a/tests/test_cookiecutter_invocation.py
+++ b/tests/test_cookiecutter_invocation.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+"""
+test_cookiecutter_invocation
+----------------------------
+
+Tests to make sure that cookiecutter can be called from the cli without
+using the entry point set up for the package.
+"""
+
+import pytest
+import subprocess
+
+
+def test_should_raise_error_without_template_arg(capfd):
+    with pytest.raises(subprocess.CalledProcessError):
+        subprocess.check_call(['python', '-m', 'cookiecutter.cli'])
+
+    _, err = capfd.readouterr()
+    exp_message = 'Error: Missing argument "template".'
+    assert exp_message in err


### PR DESCRIPTION
This PR adds very basic tests for the cli invocation for cookiecutter introduced in #449.

Albeit not strictly required, I'd prefer to have a bit of coverage for this. :no_mouth: 

Please let me know your thoughts @vincentbernat @pydanny :bow: