### PR TITLE
Leverage click version option

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -35,6 +35,7 @@ def print_version(context, param, value):
 
 
 @click.command()
+@click.version_option()
 @click.argument('template')
 @click.option(
     '--no-input', is_flag=True,
@@ -44,11 +45,6 @@ def print_version(context, param, value):
 @click.option(
     '-c', '--checkout',
     help='branch, tag or commit to checkout after git clone',
-)
-@click.option(
-    '-V', '--version',
-    is_flag=True, help='Show version information and exit.',
-    callback=print_version, expose_value=False, is_eager=True,
 )
 @click.option(
     '-v', '--verbose',

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -23,6 +23,13 @@ from cookiecutter.exceptions import OutputDirExistsException
 logger = logging.getLogger(__name__)
 
 
+def version_msg():
+    python_version = sys.version[:3]
+    location = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    message = 'Cookiecutter %(version)s from {} (Python {})'
+    return message.format(location, python_version)
+
+
 def print_version(context, param, value):
     if not value or context.resilient_parsing:
         return
@@ -35,7 +42,7 @@ def print_version(context, param, value):
 
 
 @click.command()
-@click.version_option(__version__, '-V', '--version')
+@click.version_option(__version__, '-V', '--version', message=version_msg())
 @click.argument('template')
 @click.option(
     '--no-input', is_flag=True,

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -10,7 +10,6 @@ Main `cookiecutter` CLI.
 
 from __future__ import unicode_literals
 
-import os
 import sys
 import logging
 
@@ -23,15 +22,8 @@ from cookiecutter.exceptions import OutputDirExistsException
 logger = logging.getLogger(__name__)
 
 
-def version_msg():
-    python_version = sys.version[:3]
-    location = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    message = 'Cookiecutter %(version)s from {} (Python {})'
-    return message.format(location, python_version)
-
-
 @click.command()
-@click.version_option(__version__, '-V', '--version', message=version_msg())
+@click.version_option(__version__, '-V', '--version')
 @click.argument('template')
 @click.option(
     '--no-input', is_flag=True,

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -30,17 +30,6 @@ def version_msg():
     return message.format(location, python_version)
 
 
-def print_version(context, param, value):
-    if not value or context.resilient_parsing:
-        return
-    click.echo('Cookiecutter %s from %s (Python %s)' % (
-        __version__,
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-        sys.version[:3]
-    ))
-    context.exit()
-
-
 @click.command()
 @click.version_option(__version__, '-V', '--version', message=version_msg())
 @click.argument('template')

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -35,7 +35,7 @@ def print_version(context, param, value):
 
 
 @click.command()
-@click.version_option()
+@click.version_option(None, '-V', '--version')
 @click.argument('template')
 @click.option(
     '--no-input', is_flag=True,

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -35,7 +35,7 @@ def print_version(context, param, value):
 
 
 @click.command()
-@click.version_option(None, '-V', '--version')
+@click.version_option(__version__, '-V', '--version')
 @click.argument('template')
 @click.option(
     '--no-input', is_flag=True,

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -22,7 +22,7 @@ from cookiecutter.exceptions import OutputDirExistsException
 logger = logging.getLogger(__name__)
 
 
-@click.command()
+@click.command('cookiecutter')
 @click.version_option(__version__, '-V', '--version')
 @click.argument('template')
 @click.option(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,8 +3,9 @@ import pytest
 
 from click.testing import CliRunner
 
-from cookiecutter.cli import main
+from cookiecutter import __version__
 from cookiecutter import utils
+from cookiecutter.cli import main
 
 runner = CliRunner()
 
@@ -37,7 +38,9 @@ def version_cli_flag(request):
 def test_cli_version(version_cli_flag):
     result = runner.invoke(main, [version_cli_flag])
     assert result.exit_code == 0
-    assert result.output.startswith('Cookiecutter')
+
+    exp_message = 'cookiecutter, version {}'.format(__version__)
+    assert result.output == exp_message
 
 
 @pytest.mark.usefixtures('make_fake_project_dir', 'remove_fake_project_dir')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,7 +39,7 @@ def test_cli_version(version_cli_flag):
     result = runner.invoke(main, [version_cli_flag])
     assert result.exit_code == 0
 
-    exp_message = 'cookiecutter, version {}'.format(__version__)
+    exp_message = 'cookiecutter, version {}\n'.format(__version__)
     assert result.output == exp_message
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,8 +29,13 @@ def make_fake_project_dir(request):
         os.makedirs('fake-project')
 
 
-def test_cli_version():
-    result = runner.invoke(main, ['-V'])
+@pytest.fixture(params=['-V', '--version'])
+def version_cli_flag(request):
+    return request.param
+
+
+def test_cli_version(version_cli_flag):
+    result = runner.invoke(main, [version_cli_flag])
     assert result.exit_code == 0
     assert result.output.startswith('Cookiecutter')
 


### PR DESCRIPTION
This PR makes use of **clicks** feature of printing the package version. It will not break the current format though.

```
Cookiecutter 1.0.0 from /Users/raphael/hackebrot/cookiecutter (Python 2.7)
```

If you agree on the following **click** default message, I'll get rid of ``version_msg`` altogether:

```
cookiecutter, version 1.0.0
```