### PR TITLE
Add a flag to overwrite existing output directory

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -61,7 +61,11 @@ def print_version(context, param, value):
     help='Do not prompt for parameters and only use information entered '
          'previously',
 )
-def main(template, no_input, checkout, verbose, replay):
+@click.option(
+    '-f', '--overwrite-if-exists', is_flag=True,
+    help='Overwrite the contents of the output directory if it already exists'
+)
+def main(template, no_input, checkout, verbose, replay, overwrite_if_exists):
     """Create a project from a Cookiecutter project template (TEMPLATE)."""
     if verbose:
         logging.basicConfig(
@@ -76,7 +80,8 @@ def main(template, no_input, checkout, verbose, replay):
         )
 
     try:
-        cookiecutter(template, checkout, no_input, replay=replay)
+        cookiecutter(template, checkout, no_input, replay=replay,
+                     overwrite_if_exists=overwrite_if_exists)
     except (OutputDirExistsException, InvalidModeException) as e:
         click.echo(e)
         sys.exit(1)

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -152,7 +152,8 @@ def generate_file(project_dir, infile, context, env):
     shutil.copymode(infile, outfile)
 
 
-def render_and_create_dir(dirname, context, output_dir, fail_if_exists=False):
+def render_and_create_dir(dirname, context, output_dir,
+                          overwrite_if_exists=False):
     """
     Renders the name of a directory, creates the directory, and
     returns its path.
@@ -168,8 +169,14 @@ def render_and_create_dir(dirname, context, output_dir, fail_if_exists=False):
         os.path.join(output_dir, rendered_dirname)
     )
 
-    if fail_if_exists:
-        if os.path.exists(dir_to_create):
+    output_dir_exists = os.path.exists(dir_to_create)
+
+    if overwrite_if_exists:
+        if output_dir_exists:
+            logging.debug('Output directory {} already exists,'
+                          'overwriting it'.format(dir_to_create))
+    else:
+        if output_dir_exists:
             msg = 'Error: "{}" directory already exists'.format(dir_to_create)
             raise OutputDirExistsException(msg)
 
@@ -187,13 +194,16 @@ def ensure_dir_is_templated(dirname):
         raise NonTemplatedInputDirException
 
 
-def generate_files(repo_dir, context=None, output_dir='.'):
+def generate_files(repo_dir, context=None, output_dir='.',
+                   overwrite_if_exists=False):
     """
     Renders the templates and saves them to files.
 
     :param repo_dir: Project template input directory.
     :param context: Dict for populating the template's variables.
     :param output_dir: Where to output the generated project dir into.
+    :param overwrite_if_exists: Overwrite teh contents of the output directory
+        if it exists
     """
 
     template_dir = find_template(repo_dir)
@@ -205,7 +215,7 @@ def generate_files(repo_dir, context=None, output_dir='.'):
     project_dir = render_and_create_dir(unrendered_dir,
                                         context,
                                         output_dir,
-                                        fail_if_exists=True)
+                                        overwrite_if_exists)
 
     # We want the Jinja path and the OS paths to match. Consequently, we'll:
     #   + CD to the template folder
@@ -256,7 +266,8 @@ def generate_files(repo_dir, context=None, output_dir='.'):
             dirs[:] = render_dirs
             for d in dirs:
                 unrendered_dir = os.path.join(project_dir, root, d)
-                render_and_create_dir(unrendered_dir, context, output_dir)
+                render_and_create_dir(unrendered_dir, context, output_dir,
+                                      overwrite_if_exists)
 
             for f in files:
                 infile = os.path.normpath(os.path.join(root, f))

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -84,11 +84,10 @@ def cookiecutter(
     :param: overwrite_if_exists: Overwrite the contents of output directory
         if it exists
     """
-    if replay and ((no_input is not False) or (extra_context is not None) or
-                   (overwrite_if_exists is not False)):
+    if replay and ((no_input is not False) or (extra_context is not None)):
         err_msg = (
-            "You can not use replay with no_input, extra_context"
-            " or overwrite_if_exists"
+            "You can not use both replay and no_input or extra_context "
+            "at the same time."
         )
         raise InvalidModeException(err_msg)
 

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -70,8 +70,8 @@ def expand_abbreviations(template, config_dict):
 
 
 def cookiecutter(
-        template,
-        checkout=None, no_input=False, extra_context=None, replay=False):
+        template, checkout=None, no_input=False, extra_context=None,
+        replay=False, overwrite_if_exists=False):
     """
     API equivalent to using Cookiecutter at the command line.
 
@@ -81,11 +81,14 @@ def cookiecutter(
     :param no_input: Prompt the user at command line for manual configuration?
     :param extra_context: A dictionary of context that overrides default
         and user configuration.
+    :param: overwrite_if_exists: Overwrite the contents of output directory
+        if it exists
     """
-    if replay and ((no_input is not False) or (extra_context is not None)):
+    if replay and ((no_input is not False) or (extra_context is not None) or
+                   (overwrite_if_exists is not False)):
         err_msg = (
-            "You can not use both replay and no_input or extra_context "
-            "at the same time."
+            "You can not use replay with no_input, extra_context"
+            " or overwrite_if_exists"
         )
         raise InvalidModeException(err_msg)
 
@@ -130,5 +133,6 @@ def cookiecutter(
     # Create project from local context and project template.
     generate_files(
         repo_dir=repo_dir,
-        context=context
+        context=context,
+        overwrite_if_exists=overwrite_if_exists
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,8 +99,8 @@ def test_cli_exit_on_noinput_and_replay(mocker):
     assert result.exit_code == 1
 
     expected_error_msg = (
-        "You can not use replay with no_input, extra_context or"
-        " overwrite_if_exists"
+        "You can not use both replay and no_input or extra_context "
+        "at the same time."
     )
 
     assert expected_error_msg in result.output
@@ -128,14 +128,7 @@ def test_cli_exit_on_overwrite_if_exists_and_replay(mocker):
         '-f',
     ])
 
-    assert result.exit_code == 1
-
-    expected_error_msg = (
-        "You can not use replay with no_input, extra_context or"
-        " overwrite_if_exists"
-    )
-
-    assert expected_error_msg in result.output
+    assert result.exit_code == 0
 
     mock_cookiecutter.assert_called_once_with(
         template_path,


### PR DESCRIPTION
Fix issue #493 and allow the user to alter the default behaviour
behaviour of not overwriting the contents of the output directory
if it already exists. Fix issue #475 by removing the conflicting
use of 'fail_if_exists' arguments and refactoring it.