### PR TITLE
cli: don't use unicode_literals to please click

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -8,8 +8,6 @@ cookiecutter.cli
 Main `cookiecutter` CLI.
 """
 
-from __future__ import unicode_literals
-
 import os
 import sys
 import logging
@@ -28,46 +26,46 @@ logger = logging.getLogger(__name__)
 def version_msg():
     python_version = sys.version[:3]
     location = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    message = 'Cookiecutter %(version)s from {} (Python {})'
+    message = u'Cookiecutter %(version)s from {} (Python {})'
     return message.format(location, python_version)
 
 
 @click.command()
-@click.version_option(__version__, '-V', '--version', message=version_msg())
-@click.argument('template')
+@click.version_option(__version__, u'-V', u'--version', message=version_msg())
+@click.argument(u'template')
 @click.option(
-    '--no-input', is_flag=True,
-    help='Do not prompt for parameters and only use cookiecutter.json '
-         'file content',
+    u'--no-input', is_flag=True,
+    help=u'Do not prompt for parameters and only use cookiecutter.json '
+         u'file content',
 )
 @click.option(
-    '-c', '--checkout',
-    help='branch, tag or commit to checkout after git clone',
+    u'-c', u'--checkout',
+    help=u'branch, tag or commit to checkout after git clone',
 )
 @click.option(
     '-v', '--verbose',
     is_flag=True, help='Print debug information', default=False
 )
 @click.option(
-    '--replay', is_flag=True,
-    help='Do not prompt for parameters and only use information entered '
-         'previously',
+    u'--replay', is_flag=True,
+    help=u'Do not prompt for parameters and only use information entered '
+         u'previously',
 )
 @click.option(
-    '-f', '--overwrite-if-exists', is_flag=True,
-    help='Overwrite the contents of the output directory if it already exists'
+    u'-f', u'--overwrite-if-exists', is_flag=True,
+    help=u'Overwrite the contents of the output directory if it already exists'
 )
 def main(template, no_input, checkout, verbose, replay, overwrite_if_exists):
     """Create a project from a Cookiecutter project template (TEMPLATE)."""
     if verbose:
         logging.basicConfig(
-            format='%(levelname)s %(filename)s: %(message)s',
+            format=u'%(levelname)s %(filename)s: %(message)s',
             level=logging.DEBUG
         )
     else:
         # Log info and above to console
         logging.basicConfig(
-            format='%(levelname)s: %(message)s',
+            format=u'%(levelname)s: %(message)s',
             level=logging.INFO
         )
 

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -8,7 +8,6 @@ cookiecutter.prompt
 Functions for prompting the user for project info.
 """
 
-from __future__ import unicode_literals
 from collections import OrderedDict
 
 import click
@@ -62,16 +61,16 @@ def read_user_choice(var_name, options):
         raise ValueError
 
     choice_map = OrderedDict(
-        ('{}'.format(i), value) for i, value in enumerate(options, 1)
+        (u'{}'.format(i), value) for i, value in enumerate(options, 1)
     )
     choices = choice_map.keys()
-    default = '1'
+    default = u'1'
 
-    choice_lines = ['{} - {}'.format(*c) for c in choice_map.items()]
-    prompt = '\n'.join((
-        'Select {}:'.format(var_name),
-        '\n'.join(choice_lines),
-        'Choose from {}'.format(', '.join(choices))
+    choice_lines = [u'{} - {}'.format(*c) for c in choice_map.items()]
+    prompt = u'\n'.join((
+        u'Select {}:'.format(var_name),
+        u'\n'.join(choice_lines),
+        u'Choose from {}'.format(u', '.join(choices))
     ))
 
     user_choice = click.prompt(
@@ -111,8 +110,8 @@ def prompt_for_config(context, no_input=False):
     cookiecutter_dict = {}
     env = Environment()
 
-    for key, raw in iteritems(context['cookiecutter']):
-        if key.startswith('_'):
+    for key, raw in iteritems(context[u'cookiecutter']):
+        if key.startswith(u'_'):
             cookiecutter_dict[key] = raw
             continue
 


### PR DESCRIPTION
The reason are explained in this thread:
 https://github.com/PythonCharmers/python-future/issues/22

Just remove unicode_literals from `cookiecutter/cli.py` as it is the
first use of click. However, it should also be removed from
`cookiecutter/prompt.py`.