### PR TITLE
Use click version

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -37,6 +37,7 @@ def print_version(context, param, value):
 
 
 @click.command()
+@click.version_option()
 @click.argument('template')
 @click.option(
     '--no-input', is_flag=True,
@@ -46,11 +47,6 @@ def print_version(context, param, value):
 @click.option(
     '-c', '--checkout',
     help='branch, tag or commit to checkout after git clone',
-)
-@click.option(
-    '-V', '--version',
-    is_flag=True, help='Show version information and exit.',
-    callback=print_version, expose_value=False, is_eager=True,
 )
 @click.option(
     '-v', '--verbose',

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -32,17 +32,6 @@ def version_msg():
     return message.format(location, python_version)
 
 
-def print_version(context, param, value):
-    if not value or context.resilient_parsing:
-        return
-    click.echo('Cookiecutter %s from %s (Python %s)' % (
-        __version__,
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-        sys.version[:3]
-    ))
-    context.exit()
-
-
 @click.command()
 @click.version_option(__version__, '-V', '--version', message=version_msg())
 @click.argument('template')

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -37,7 +37,7 @@ def print_version(context, param, value):
 
 
 @click.command()
-@click.version_option()
+@click.version_option(None, '-V', '--version')
 @click.argument('template')
 @click.option(
     '--no-input', is_flag=True,

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -37,7 +37,7 @@ def print_version(context, param, value):
 
 
 @click.command()
-@click.version_option(None, '-V', '--version')
+@click.version_option(__version__, '-V', '--version')
 @click.argument('template')
 @click.option(
     '--no-input', is_flag=True,

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -25,6 +25,13 @@ from cookiecutter.exceptions import (
 logger = logging.getLogger(__name__)
 
 
+def version_msg():
+    python_version = sys.version[:3]
+    location = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    message = 'Cookiecutter %(version)s from {} (Python {})'
+    return message.format(location, python_version)
+
+
 def print_version(context, param, value):
     if not value or context.resilient_parsing:
         return
@@ -37,7 +44,7 @@ def print_version(context, param, value):
 
 
 @click.command()
-@click.version_option(__version__, '-V', '--version')
+@click.version_option(__version__, '-V', '--version', message=version_msg())
 @click.argument('template')
 @click.option(
     '--no-input', is_flag=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,8 +30,13 @@ def make_fake_project_dir(request):
         os.makedirs('fake-project')
 
 
-def test_cli_version():
-    result = runner.invoke(main, ['-V'])
+@pytest.fixture(params=['-V', '--version'])
+def version_cli_flag(request):
+    return request.param
+
+
+def test_cli_version(version_cli_flag):
+    result = runner.invoke(main, [version_cli_flag])
     assert result.exit_code == 0
     assert result.output.startswith('Cookiecutter')
 


### PR DESCRIPTION
Make use of ``click.version_option`` without changing the current prompt.

This PR also adds a test for the ``--version`` cli option.

Based on the feedback to #489.