### PR TITLE
Export tox environment variables to codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ env:
 script: tox -e $TOX_ENV
 
 install:
-    - pip install tox
+    - pip install tox codecov
 
 after_success:
     # Report coverage results to codecov.io
-    - pip install codecov
-    - codecov
+    # and export tox environment variables
+    - codecov -e TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ env:
 script: tox -e $TOX_ENV
 
 install:
-    - pip install tox codecov
+    - pip install tox
 
 after_success:
     # Report coverage results to codecov.io
     # and export tox environment variables
+    - pip install codecov
     - codecov -e TOX_ENV


### PR DESCRIPTION
This will export tox environment variables such as py27, py33, ... to codecov. Codecov will then show these variables when an individual travis build run is selected. This is very handy to see what environment is selected, when a individual environment is selected for coverage results instead of the unified results. Here is an example how this looks in the UI for this PR: https://codecov.io/github/audreyr/cookiecutter?ref=533143d96a2a879b69689ca30b83593fcd7cb7fb&build=1051.2