### PR TITLE
Extend flake8 checks

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     flake8==2.3.0
     pep8==1.6.2
 commands =
-    flake8 cookiecutter
+    flake8 cookiecutter tests
 
 [testenv:cov-report]
 commands = py.test --cov=cookiecutter --cov-report=term --cov-report=html

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     flake8==2.3.0
     pep8==1.6.2
 commands =
-    flake8 cookiecutter tests
+    flake8 cookiecutter tests setup.py
 
 [testenv:cov-report]
 commands = py.test --cov=cookiecutter --cov-report=term --cov-report=html


### PR DESCRIPTION
This PR extend the ``flake8`` testenv to also validate the ``tests`` subdir as well as ``setup.py``. :triumph: 