### PR TITLE
expanduser does not resolve "~" correctly on windows 10 using tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py27, py33, py34, py35, pypy, flake8
 
 [testenv]
-passenv = LC_ALL, LANG
+passenv = LC_ALL, LANG, HOME
 commands = py.test --cov=cookiecutter {posargs:tests}
 deps = pytest
        pytest-cov


### PR DESCRIPTION
# Preq

Currently my box is windows 10 with git bash (not the newest version), ConEmu (as a wrapper to make git bash look good), virtualenvwrapper and git-flow. 

# Desc

When testing locally with tox, I noticed that after all tests ran a leftover directory named "~" persists in my cookiecutter directory. 
```
repo/cookiecutter
                |
                - ~/
                |
                - tests/
                |
                - cookiecutter/
                |
                - setup.py
                |
                - ...
```

I guess there are multiple tests responsible for this, but I nailed down one test, that reproduces the bug on my machine. 

```tox -e py34 -r  -- tests/test_cookiecutter_local_no_input.py::test_cookiecutter_no_input_extra_context```

It can be reproduced on all Python versions supported. I wasn't sure what the problem is as it does not seem to happen on unix machines and I am still not sure if this is a problem of my environment setup, but throwing in some debugging statements one can find this: 

```python
> c:\users\maiksen\repos\cookiecutter\cookiecutter\config.py(65)get_user_config()
-> return copy.copy(DEFAULT_CONFIG)
(Pdb) l
 60         # TODO: test on windows...
 61         USER_CONFIG_PATH = os.path.expanduser('~/.cookiecutterrc')
 62
 63         if os.path.exists(USER_CONFIG_PATH):
 64             return get_config(USER_CONFIG_PATH)
 65  ->     return copy.copy(DEFAULT_CONFIG)
[EOF]
(Pdb) step
--Call--
> c:\python27\lib\copy.py(66)copy()
-> def copy(x):
(Pdb) args
x = {u'cookiecutters_dir': u'~/.cookiecutters/', u'replay_dir': u'~/.cookiecutter_replay/', u'default_context': {}}
(Pdb)
```
where you can see, that no directory got expanded correctly. I also debugged expanduser and it cant find a variable for the mapping to my home. 
I guess this is due to the fact, that tox uses a sandboxed cmd without any `HOME` / `HOMEDIR` variables set. On unix this aint a problem as '~' always leads to the current home, no matter how minimal or sandboxed a shell environment is. 
On windows though, without a `HOME` set, this leads ```os.path.expanduser``` to expand '~' to '~', which is relative to the root of cookiecutter. 
A fix is to pass `HOME` with tox. I already tested it locally, which seems to work. I would love for people to also test this locally on their machines to ensure this does not cause any strange behaviours on unix machines. 