### PR TITLE
Use future instead of custom compat

### DIFF
--- a/cookiecutter/__init__.py
+++ b/cookiecutter/__init__.py
@@ -7,10 +7,10 @@ cookiecutter
 
 Main package for Cookiecutter.
 """
-from .compat import OLD_PY2
+import sys
 
 __version__ = '1.0.0'
 
-if OLD_PY2:
+if sys.version_info[:2] < (2, 7):
     msg = 'Python 2.6 support was removed from cookiecutter in release 1.0.0.'
     raise DeprecationWarning(msg)

--- a/cookiecutter/compat.py
+++ b/cookiecutter/compat.py
@@ -2,11 +2,3 @@ import sys
 
 PY3 = sys.version_info[0] == 3
 OLD_PY2 = sys.version_info[:2] < (2, 7)
-
-
-if PY3:  # pragma: no cover
-    iteritems = lambda d: iter(d.items())
-
-
-else:  # pragma: no cover
-    iteritems = lambda d: d.iteritems()

--- a/cookiecutter/compat.py
+++ b/cookiecutter/compat.py
@@ -5,14 +5,10 @@ OLD_PY2 = sys.version_info[:2] < (2, 7)
 
 
 if PY3:  # pragma: no cover
-    input_str = 'builtins.input'
     iteritems = lambda d: iter(d.items())
 
 
 else:  # pragma: no cover
-    from __builtin__ import raw_input
-    input = raw_input
-    input_str = '__builtin__.raw_input'
     iteritems = lambda d: d.iteritems()
 
 

--- a/cookiecutter/compat.py
+++ b/cookiecutter/compat.py
@@ -1,3 +1,0 @@
-import sys
-
-PY3 = sys.version_info[0] == 3

--- a/cookiecutter/compat.py
+++ b/cookiecutter/compat.py
@@ -10,8 +10,3 @@ if PY3:  # pragma: no cover
 
 else:  # pragma: no cover
     iteritems = lambda d: d.iteritems()
-
-
-def is_string(obj):
-    """Determine if an object is a string."""
-    return isinstance(obj, str if PY3 else basestring)

--- a/cookiecutter/compat.py
+++ b/cookiecutter/compat.py
@@ -1,4 +1,3 @@
 import sys
 
 PY3 = sys.version_info[0] == 3
-OLD_PY2 = sys.version_info[:2] < (2, 7)

--- a/cookiecutter/compat.py
+++ b/cookiecutter/compat.py
@@ -7,7 +7,6 @@ OLD_PY2 = sys.version_info[:2] < (2, 7)
 if PY3:  # pragma: no cover
     input_str = 'builtins.input'
     iteritems = lambda d: iter(d.items())
-    from io import StringIO
 
 
 else:  # pragma: no cover
@@ -15,12 +14,8 @@ else:  # pragma: no cover
     input = raw_input
     input_str = '__builtin__.raw_input'
     iteritems = lambda d: d.iteritems()
-    from cStringIO import StringIO
 
 
 def is_string(obj):
     """Determine if an object is a string."""
     return isinstance(obj, str if PY3 else basestring)
-
-
-_hush_pyflakes = (StringIO)

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -11,8 +11,9 @@ Functions for prompting the user for project info.
 from collections import OrderedDict
 
 import click
+from past.builtins import basestring
 
-from .compat import iteritems, is_string
+from .compat import iteritems
 from jinja2.environment import Environment
 
 
@@ -80,7 +81,7 @@ def read_user_choice(var_name, options):
 
 
 def render_variable(env, raw, cookiecutter_dict):
-    if not is_string(raw):
+    if not isinstance(raw, basestring):
         raw = str(raw)
     template = env.from_string(raw)
     rendered_template = template.render(cookiecutter=cookiecutter_dict)

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -13,7 +13,7 @@ from collections import OrderedDict
 import click
 from past.builtins import basestring
 
-from .compat import iteritems
+from future.utils import iteritems
 from jinja2.environment import Environment
 
 

--- a/cookiecutter/replay.py
+++ b/cookiecutter/replay.py
@@ -9,8 +9,8 @@ from __future__ import unicode_literals
 
 import json
 import os
+from past.builtins import basestring
 
-from .compat import is_string
 from .config import get_user_config
 from .utils import make_sure_path_exists
 
@@ -21,7 +21,7 @@ def get_file_name(replay_dir, template_name):
 
 
 def dump(template_name, context):
-    if not is_string(template_name):
+    if not isinstance(template_name, basestring):
         raise TypeError('Template name is required to be of type str')
 
     if not isinstance(context, dict):
@@ -42,7 +42,7 @@ def dump(template_name, context):
 
 
 def load(template_name):
-    if not is_string(template_name):
+    if not isinstance(template_name, basestring):
         raise TypeError('Template name is required to be of type str')
 
     replay_dir = get_user_config()['replay_dir']

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 requirements = [
+    'future>=0.15.2',
     'binaryornot>=0.2.0',
     'jinja2>=2.7',
     'PyYAML>=3.10',

--- a/tests/test_preferred_encoding.py
+++ b/tests/test_preferred_encoding.py
@@ -3,8 +3,9 @@
 import locale
 import codecs
 import pytest
+import sys
 
-from cookiecutter.compat import PY3
+PY3 = sys.version_info[0] == 3
 
 
 @pytest.mark.skipif(not PY3, reason='Only necessary on Python3')

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -12,8 +12,9 @@ from collections import OrderedDict
 import platform
 
 import pytest
+from past.builtins import basestring
 
-from cookiecutter import prompt, compat
+from cookiecutter import prompt
 from jinja2.environment import Environment
 
 
@@ -35,7 +36,7 @@ def test_convert_to_str(mocker, raw_var, rendered_var):
     assert result == rendered_var
 
     # Make sure that non str variables are conerted beforehand
-    if not compat.is_string(raw_var):
+    if not isinstance(raw_var, basestring):
         raw_var = str(raw_var)
     from_string.assert_called_once_with(raw_var)
 


### PR DESCRIPTION
Remove ``compat.py`` and use [future](https://pypi.python.org/pypi/future) for ``basestring`` and ``iteritems``.

Resolve #298 with regards to #438. Also resolve #301 cc @michaeljoseph @pydanny 