### PR TITLE
Specify output dir

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -55,7 +55,12 @@ def version_msg():
     u'-f', u'--overwrite-if-exists', is_flag=True,
     help=u'Overwrite the contents of the output directory if it already exists'
 )
-def main(template, no_input, checkout, verbose, replay, overwrite_if_exists):
+@click.option(
+    u'-o', u'--output-dir', default='.', type=click.Path(),
+    help=u'Where to output the generated project dir into'
+)
+def main(template, no_input, checkout, verbose, replay, overwrite_if_exists,
+         output_dir):
     """Create a project from a Cookiecutter project template (TEMPLATE)."""
     if verbose:
         logging.basicConfig(
@@ -70,8 +75,12 @@ def main(template, no_input, checkout, verbose, replay, overwrite_if_exists):
         )
 
     try:
-        cookiecutter(template, checkout, no_input, replay=replay,
-                     overwrite_if_exists=overwrite_if_exists)
+        cookiecutter(
+            template, checkout, no_input,
+            replay=replay,
+            overwrite_if_exists=overwrite_if_exists,
+            output_dir=output_dir
+        )
     except (OutputDirExistsException, InvalidModeException) as e:
         click.echo(e)
         sys.exit(1)

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -71,7 +71,7 @@ def expand_abbreviations(template, config_dict):
 
 def cookiecutter(
         template, checkout=None, no_input=False, extra_context=None,
-        replay=False, overwrite_if_exists=False):
+        replay=False, overwrite_if_exists=False, output_dir='.'):
     """
     API equivalent to using Cookiecutter at the command line.
 
@@ -83,6 +83,7 @@ def cookiecutter(
         and user configuration.
     :param: overwrite_if_exists: Overwrite the contents of output directory
         if it exists
+    :param output_dir: Where to output the generated project dir into.
     """
     if replay and ((no_input is not False) or (extra_context is not None)):
         err_msg = (
@@ -133,5 +134,6 @@ def cookiecutter(
     generate_files(
         repo_dir=repo_dir,
         context=context,
-        overwrite_if_exists=overwrite_if_exists
+        overwrite_if_exists=overwrite_if_exists,
+        output_dir=output_dir
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,7 +79,8 @@ def test_cli_replay(mocker):
         None,
         False,
         replay=True,
-        overwrite_if_exists=False
+        overwrite_if_exists=False,
+        output_dir='.'
     )
 
 
@@ -112,7 +113,8 @@ def test_cli_exit_on_noinput_and_replay(mocker):
         None,
         True,
         replay=True,
-        overwrite_if_exists=False
+        overwrite_if_exists=False,
+        output_dir='.'
     )
 
 
@@ -144,7 +146,8 @@ def test_run_cookiecutter_on_overwrite_if_exists_and_replay(
         None,
         False,
         replay=True,
-        overwrite_if_exists=True
+        overwrite_if_exists=True,
+        output_dir='.'
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,3 +167,36 @@ def test_cli_overwrite_if_exists_when_output_dir_exists(overwrite_cli_flag):
 
     assert result.exit_code == 0
     assert os.path.isdir('fake-project')
+
+
+@pytest.fixture(params=['-o', '--output-dir'])
+def output_dir_flag(request):
+    return request.param
+
+
+@pytest.fixture
+def output_dir(tmpdir):
+    return str(tmpdir.mkdir('output'))
+
+
+def test_cli_output_dir(mocker, output_dir_flag, output_dir):
+    mock_cookiecutter = mocker.patch(
+        'cookiecutter.cli.cookiecutter'
+    )
+
+    template_path = 'tests/fake-repo-pre/'
+    result = runner.invoke(main, [
+        template_path,
+        output_dir_flag,
+        output_dir
+    ])
+
+    assert result.exit_code == 0
+    mock_cookiecutter.assert_called_once_with(
+        template_path,
+        None,
+        False,
+        replay=False,
+        overwrite_if_exists=False,
+        output_dir=output_dir
+    )

--- a/tests/test_specify_output_dir.py
+++ b/tests/test_specify_output_dir.py
@@ -20,12 +20,12 @@ def context():
 
 @pytest.fixture
 def output_dir(tmpdir):
-    return tmpdir.mkdir('output')
+    return str(tmpdir.mkdir('output'))
 
 
 @pytest.fixture
 def template(tmpdir):
-    return tmpdir.mkdir('template')
+    return str(tmpdir.mkdir('template'))
 
 
 @pytest.fixture(autouse=True)
@@ -49,8 +49,9 @@ def test_api_invocation(mocker, template, output_dir, context):
     main.cookiecutter(template, output_dir=output_dir)
 
     mock_gen_files.assert_called_once_with(
-        template,
-        context,
+        repo_dir=template,
+        context=context,
+        overwrite_if_exists=False,
         output_dir=output_dir
     )
 
@@ -61,7 +62,8 @@ def test_default_output_dir(mocker, template, context):
     main.cookiecutter(template)
 
     mock_gen_files.assert_called_once_with(
-        template,
-        context,
+        repo_dir=template,
+        context=context,
+        overwrite_if_exists=False,
         output_dir='.'
     )

--- a/tests/test_specify_output_dir.py
+++ b/tests/test_specify_output_dir.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from cookiecutter import main
+
+
+@pytest.fixture
+def context():
+    """Fixture to return a valid context as known from a cookiecutter.json."""
+    return {
+        u'cookiecutter': {
+            u'email': u'raphael@hackebrot.de',
+            u'full_name': u'Raphael Pierzina',
+            u'github_username': u'hackebrot',
+            u'version': u'0.1.0',
+        }
+    }
+
+
+@pytest.fixture
+def output_dir(tmpdir):
+    return tmpdir.mkdir('output')
+
+
+@pytest.fixture
+def template(tmpdir):
+    return tmpdir.mkdir('template')
+
+
+@pytest.fixture(autouse=True)
+def mock_gen_context(mocker, context):
+    mocker.patch('cookiecutter.main.generate_context', return_value=context)
+
+
+@pytest.fixture(autouse=True)
+def mock_prompt(mocker):
+    mocker.patch('cookiecutter.main.prompt_for_config')
+
+
+@pytest.fixture(autouse=True)
+def mock_replay(mocker):
+    mocker.patch('cookiecutter.main.dump')
+
+
+def test_api_invocation(mocker, template, output_dir, context):
+    mock_gen_files = mocker.patch('cookiecutter.main.generate_files')
+
+    main.cookiecutter(template, output_dir=output_dir)
+
+    mock_gen_files.assert_called_once_with(
+        template,
+        context,
+        output_dir=output_dir
+    )

--- a/tests/test_specify_output_dir.py
+++ b/tests/test_specify_output_dir.py
@@ -53,3 +53,15 @@ def test_api_invocation(mocker, template, output_dir, context):
         context,
         output_dir=output_dir
     )
+
+
+def test_default_output_dir(mocker, template, context):
+    mock_gen_files = mocker.patch('cookiecutter.main.generate_files')
+
+    main.cookiecutter(template)
+
+    mock_gen_files.assert_called_once_with(
+        template,
+        context,
+        output_dir='.'
+    )


### PR DESCRIPTION
Continue the work of @tony to add support for specifying the output directory (resolve #452).

I also added an according cli option:

```bash
$ cookiecutter -o tmp/foobar gh:hackebrot/cookiedozer
```
or

```bash
$ cookiecutter --output-dir tmp/foobar gh:hackebrot/cookiedozer
```

You can also use the Python API via:

```python
from cookiecutter import main
main('gh:hackebrot/cookiedozer', output_dir='tmp/foobar')
```
I also think it would be great to include this in the upcoming **Cookiecutter 1.1.0** release (#530).

*Please note that I did not include the changes to existing tests of #452.*


cc @tony, @cabello, @jefftriplett and @davedash 