### PR TITLE
Fix is repo url for win path

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -32,9 +32,9 @@ builtin_abbreviations = {
 
 REPO_REGEX = """
 (
-(\w+:(//)?)          # something like git:// ssh:// etc.
- |                   # or
- (\w+@[\w\.]+)       # something like user@...
+((git|ssh|https|http):(//)?)    # something like git:// ssh:// etc.
+ |                              # or
+ (\w+@[\w\.]+)                  # something like user@...
 )
 .*
 """

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,3 +11,9 @@ def test_is_repo_url():
 
     assert is_repo_url('/audreyr/cookiecutter.git') is False
     assert is_repo_url('/home/audreyr/cookiecutter') is False
+
+    appveyor_temp_dir = (
+        'c:\\users\\appveyor\\appdata\\local\\temp\\1\\pytest-0\\'
+        'test_default_output_dir0\\template'
+    )
+    assert is_repo_url(appveyor_temp_dir) is False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,4 @@
-from cookiecutter.main import is_repo_url
+from cookiecutter.main import is_repo_url, expand_abbreviations
 
 
 def test_is_repo_url():
@@ -6,7 +6,6 @@ def test_is_repo_url():
     assert is_repo_url('gitolite@server:team/repo') is True
     assert is_repo_url('git@github.com:audreyr/cookiecutter.git') is True
     assert is_repo_url('https://github.com/audreyr/cookiecutter.git') is True
-    assert is_repo_url('gh:audreyr/cookiecutter-pypackage') is True
     assert is_repo_url('https://bitbucket.org/pokoli/cookiecutter.hg') is True
 
     assert is_repo_url('/audreyr/cookiecutter.git') is False
@@ -17,3 +16,14 @@ def test_is_repo_url():
         'test_default_output_dir0\\template'
     )
     assert is_repo_url(appveyor_temp_dir) is False
+
+
+def test_expand_abbreviations():
+    template = 'gh:audreyr/cookiecutter-pypackage'
+
+    # This is not a valid repo url just yet!
+    # First `main.expand_abbreviations` needs to translate it
+    assert is_repo_url(template) is False
+
+    expanded_template = expand_abbreviations(template, {})
+    assert is_repo_url(expanded_template) is True


### PR DESCRIPTION
This PR changes the regex for ``is_repo_url`` as local windows paths seemed to be mistaken for remote urls, see #531. :cry: 

https://ci.appveyor.com/project/audreyr/cookiecutter/build/1.0.656/job/9vjf6xlxxx4sfvj4