### PR TITLE
enable py35 support on travis by using python3.5 as base python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@
 
 sudo: false
 language: python
-python: 2.7
+python: 3.5
 env:
     - TOX_ENV=py27
     - TOX_ENV=py33
     - TOX_ENV=py34
+    - TOX_ENV=py35
     - TOX_ENV=pypy
     - TOX_ENV=flake8
 


### PR DESCRIPTION
Please See travis-ci/travis-ci#4794 
It looks like they wont change anything on their build image soon. This is why I changed the base python version for the travis build job to 3.5, which simply downloads python 3.5 as long as it is not installed (https://travis-ci.org/audreyr/cookiecutter/jobs/82566099).