### PR TITLE
Choice with default in user config

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -51,6 +51,7 @@ def copy_without_render(path, context):
 
 
 def apply_overwrites_to_context(context, overwrite_context):
+    """Modify the given context in place based on the overwrite_context."""
     for variable, overwrite in overwrite_context.items():
         if variable not in context:
             # Do not include variables which are not used in the template

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -53,9 +53,7 @@ def copy_without_render(path, context):
 def apply_overwrites_to_context(context, overwrite_context):
     for variable, overwrite in overwrite_context.items():
         if variable not in context:
-            # Albeit not relevant for the template, set this variable to
-            # resemble ``dict.update()``
-            context[variable] = overwrite
+            # Do not include variables which are not used in the template
             continue
 
         context_value = context[variable]

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -50,6 +50,29 @@ def copy_without_render(path, context):
     return False
 
 
+def apply_overwrites_to_context(context, overwrite_context):
+    for variable, overwrite in overwrite_context.items():
+        if variable not in context:
+            # Albeit not relevant for the template, set this variable to
+            # resemble ``dict.update()``
+            context[variable] = overwrite
+            continue
+
+        context_value = context[variable]
+
+        if isinstance(context_value, list):
+            # We are dealing with a choice variable
+            if overwrite in context_value:
+                # This overwrite is actually valid for the given context
+                # Let's set it as default (by definition first item in list)
+                # see ``cookiecutter.prompt.prompt_choice_for_config``
+                context_value.remove(overwrite)
+                context_value.insert(0, overwrite)
+        else:
+            # Simply overwrite the value for this variable
+            context[variable] = overwrite
+
+
 def generate_context(context_file='cookiecutter.json', default_context=None,
                      extra_context=None):
     """
@@ -85,9 +108,9 @@ def generate_context(context_file='cookiecutter.json', default_context=None,
     # Overwrite context variable defaults with the default context from the
     # user's global config, if available
     if default_context:
-        obj.update(default_context)
+        apply_overwrites_to_context(obj, default_context)
     if extra_context:
-        obj.update(extra_context)
+        apply_overwrites_to_context(obj, extra_context)
 
     logging.debug('Context generated is {0}'.format(context))
     return context

--- a/tests/test-generate-context/choices_template.json
+++ b/tests/test-generate-context/choices_template.json
@@ -1,0 +1,7 @@
+{
+    "full_name": "Raphael Pierzina",
+    "github_username": "hackebrot",
+    "project_name": "Kivy Project",
+    "repo_name": "{{cookiecutter.project_name|lower",
+    "orientation": ["all", "landscape", "portrait"]
+}

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -128,12 +128,12 @@ def test_choices(context_file, default_context, extra_context):
     config and the list as such is not changed to a single value.
     """
     expected_context = {
-        "choices_template": OrderedDict([
-            ("full_name", "Raphael Pierzina"),
-            ("github_username", "hackebrot"),
-            ("project_name", "Kivy Project"),
-            ("repo_name", "{{cookiecutter.project_name|lower"),
-            ("orientation", ["landscape", "all", "portrait"]),
+        'choices_template': OrderedDict([
+            ('full_name', 'Raphael Pierzina'),
+            ('github_username', 'hackebrot'),
+            ('project_name', 'Kivy Project'),
+            ('repo_name', '{{cookiecutter.project_name|lower'),
+            ('orientation', ['landscape', 'all', 'portrait']),
         ])
     }
 
@@ -147,11 +147,11 @@ def test_choices(context_file, default_context, extra_context):
 @pytest.fixture
 def template_context():
     return OrderedDict([
-        ("full_name", "Raphael Pierzina"),
-        ("github_username", "hackebrot"),
-        ("project_name", "Kivy Project"),
-        ("repo_name", "{{cookiecutter.project_name|lower"),
-        ("orientation", ["all", "landscape", "portrait"]),
+        ('full_name', 'Raphael Pierzina'),
+        ('github_username', 'hackebrot'),
+        ('project_name', 'Kivy Project'),
+        ('repo_name', '{{cookiecutter.project_name|lower'),
+        ('orientation', ['all', 'landscape', 'portrait']),
     ])
 
 

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -175,10 +175,18 @@ def test_apply_overwrites_sets_non_list_value(template_context):
 
 def test_apply_overwrites_does_not_modify_choices_for_invalid_overwrite(
         template_context):
-
     generate.apply_overwrites_to_context(
         template_context,
         {'orientation': 'foobar'}
     )
 
     assert template_context['orientation'] == ['all', 'landscape', 'portrait']
+
+
+def test_apply_overwrites_sets_default_for_choice_variable(template_context):
+    generate.apply_overwrites_to_context(
+        template_context,
+        {'orientation': 'landscape'}
+    )
+
+    assert template_context['orientation'] == ['landscape', 'all', 'portrait']

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -134,8 +134,6 @@ def test_choices(context_file, default_context, extra_context):
             ("project_name", "Kivy Project"),
             ("repo_name", "{{cookiecutter.project_name|lower"),
             ("orientation", ["landscape", "all", "portrait"]),
-            ("not_in_template", "foobar"),
-            ("also_not_in_template", "foobar2"),
         ])
     }
 

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -171,3 +171,14 @@ def test_apply_overwrites_sets_non_list_value(template_context):
     )
 
     assert template_context['repo_name'] == 'foobar'
+
+
+def test_apply_overwrites_does_not_modify_choices_for_invalid_overwrite(
+        template_context):
+
+    generate.apply_overwrites_to_context(
+        template_context,
+        {'orientation': 'foobar'}
+    )
+
+    assert template_context['orientation'] == ['all', 'landscape', 'portrait']

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -13,6 +13,7 @@ TestGenerateContext.test_generate_context_with_default_and_extra
 """
 
 from __future__ import unicode_literals
+import copy
 import pytest
 import os
 import re
@@ -142,3 +143,25 @@ def test_choices(context_file, default_context, extra_context):
     )
 
     assert generated_context == expected_context
+
+
+@pytest.fixture
+def template_context():
+    return OrderedDict([
+        ("full_name", "Raphael Pierzina"),
+        ("github_username", "hackebrot"),
+        ("project_name", "Kivy Project"),
+        ("repo_name", "{{cookiecutter.project_name|lower"),
+        ("orientation", ["all", "landscape", "portrait"]),
+    ])
+
+
+def test_apply_overwrites_does_include_unused_variables(template_context):
+    before = copy.deepcopy(template_context)
+
+    generate.apply_overwrites_to_context(
+        template_context,
+        {'not in template': 'foobar'}
+    )
+
+    assert template_context == before

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -165,3 +165,12 @@ def test_apply_overwrites_does_include_unused_variables(template_context):
     )
 
     assert template_context == before
+
+
+def test_apply_overwrites_sets_non_list_value(template_context):
+    generate.apply_overwrites_to_context(
+        template_context,
+        {'repo_name': 'foobar'}
+    )
+
+    assert template_context['repo_name'] == 'foobar'

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -13,7 +13,6 @@ TestGenerateContext.test_generate_context_with_default_and_extra
 """
 
 from __future__ import unicode_literals
-import copy
 import pytest
 import os
 import re
@@ -157,14 +156,12 @@ def template_context():
 
 
 def test_apply_overwrites_does_include_unused_variables(template_context):
-    before = copy.deepcopy(template_context)
-
     generate.apply_overwrites_to_context(
         template_context,
         {'not in template': 'foobar'}
     )
 
-    assert template_context == before
+    assert 'not in template' not in template_context
 
 
 def test_apply_overwrites_sets_non_list_value(template_context):


### PR DESCRIPTION
This PR makes sure to factor in choice variables in templates when using a user config or extra context.

Instead of replacing the list, it will set the *overwrite* value as the new default for the choice variable.

Please note that 8f08298 slightly changes the current behavior as it ignores variables which are not used in the template as opposed to ``dict.update({})``.

Resolve #536 