### PR TITLE
Stop project generation if pre hook script fails

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -17,7 +17,7 @@ import click
 from cookiecutter import __version__
 from cookiecutter.main import cookiecutter
 from cookiecutter.exceptions import (
-    OutputDirExistsException, InvalidModeException
+    OutputDirExistsException, InvalidModeException, FailedHookException
 )
 
 logger = logging.getLogger(__name__)
@@ -81,9 +81,11 @@ def main(template, no_input, checkout, verbose, replay, overwrite_if_exists,
             overwrite_if_exists=overwrite_if_exists,
             output_dir=output_dir
         )
-    except (OutputDirExistsException, InvalidModeException) as e:
+    except (OutputDirExistsException,
+            InvalidModeException, FailedHookException) as e:
         click.echo(e)
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/cookiecutter/exceptions.py
+++ b/cookiecutter/exceptions.py
@@ -81,3 +81,9 @@ class InvalidModeException(CookiecutterException):
     Raised when cookiecutter is called with both `no_input==True` and
     `replay==True` at the same time.
     """
+
+
+class FailedHookException(CookiecutterException):
+    """
+    Raised when a hook script fails
+    """

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -229,7 +229,7 @@ def _run_hook_from_repo_dir(repo_dir, hook_name, project_dir, context):
     """
     with work_in(repo_dir):
         try:
-            run_hook('pre_gen_project', project_dir, context)
+            run_hook(hook_name, project_dir, context)
         except FailedHookException:
             rmtree(project_dir)
             logging.error("Stopping generation because %s"

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -24,11 +24,12 @@ from binaryornot.check import is_binary
 from .exceptions import (
     NonTemplatedInputDirException,
     ContextDecodingException,
+    FailedHookException,
     OutputDirExistsException
 )
 from .find import find_template
 from .utils import make_sure_path_exists, work_in
-from .hooks import run_hook, EXIT_SUCCESS
+from .hooks import run_hook
 
 
 def copy_without_render(path, context):
@@ -257,7 +258,10 @@ def generate_files(repo_dir, context=None, output_dir='.',
 
     # run pre-gen hook from repo_dir
     with work_in(repo_dir):
-        if run_hook('pre_gen_project', project_dir, context) != EXIT_SUCCESS:
+        try:
+            run_hook('pre_gen_project', project_dir, context)
+        except FailedHookException:
+            shutil.rmtree(project_dir, ignore_errors=True)
             logging.error("Stopping generation because pre_gen_project"
                           " hook script didn't exit sucessfully")
             return

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -264,7 +264,7 @@ def generate_files(repo_dir, context=None, output_dir='.',
             shutil.rmtree(project_dir, ignore_errors=True)
             logging.error("Stopping generation because pre_gen_project"
                           " hook script didn't exit sucessfully")
-            return
+            raise
 
     with work_in(template_dir):
         env = Environment(keep_trailing_newline=True)

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -28,7 +28,7 @@ from .exceptions import (
 )
 from .find import find_template
 from .utils import make_sure_path_exists, work_in
-from .hooks import run_hook
+from .hooks import run_hook, EXIT_SUCCESS
 
 
 def copy_without_render(path, context):
@@ -257,7 +257,10 @@ def generate_files(repo_dir, context=None, output_dir='.',
 
     # run pre-gen hook from repo_dir
     with work_in(repo_dir):
-        run_hook('pre_gen_project', project_dir, context)
+        if run_hook('pre_gen_project', project_dir, context) != EXIT_SUCCESS:
+            logging.error("Stopping generation because pre_gen_project"
+                          " hook script didn't exit sucessfully")
+            return
 
     with work_in(template_dir):
         env = Environment(keep_trailing_newline=True)

--- a/cookiecutter/hooks.py
+++ b/cookiecutter/hooks.py
@@ -19,11 +19,13 @@ from jinja2 import Template
 
 from cookiecutter import utils
 
+
 _HOOKS = [
     'pre_gen_project',
     'post_gen_project',
     # TODO: other hooks should be listed here
 ]
+EXIT_SUCCESS = 0
 
 
 def find_hooks():
@@ -67,7 +69,7 @@ def run_script(script_path, cwd='.'):
         shell=run_thru_shell,
         cwd=cwd
     )
-    proc.wait()
+    return proc.wait()
 
 
 def run_script_with_context(script_path, cwd, context):
@@ -89,7 +91,7 @@ def run_script_with_context(script_path, cwd, context):
     ) as temp:
         temp.write(Template(contents).render(**context))
 
-    run_script(temp.name, cwd)
+    return run_script(temp.name, cwd)
 
 
 def run_hook(hook_name, project_dir, context):
@@ -103,5 +105,5 @@ def run_hook(hook_name, project_dir, context):
     script = find_hooks().get(hook_name)
     if script is None:
         logging.debug('No hooks found')
-        return
+        return EXIT_SUCCESS
     return run_script_with_context(script, project_dir, context)

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -37,7 +37,7 @@ on Windows) can be a quicker alternative.
 .. note::
     Make sure your hook scripts work in a robust manner. If a hook script fails
     (that is, `if it finishes with a nonzero exit status
-    <https://docs.python.org/2/library/sys.html#sys.exit>`_), the project
+    <https://docs.python.org/3/library/sys.html#sys.exit>`_), the project
     generation will stop and the generated directory will be cleaned up.
 
 Example: Validating template variables

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -35,10 +35,30 @@ template to only be run on a single platform, a shell script (or `.bat` file
 on Windows) can be a quicker alternative.
 
 .. note::
-    Make sure your hook scripts work in a robust manner.  If a hook script
-    fails (that is, if it finishes with an exit status that is not one of
-    success), the project generation will stop and the generated directory will
-    be cleaned up.
+    Make sure your hook scripts work in a robust manner. If a hook script fails
+    (that is, if it finishes with an exit status that is not ``0``), the
+    project generation will stop and the generated directory will be cleaned
+    up.
+
+Example: Validating template variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Here is an example of script that validates a template variable
+before generating the project, to be used as ``hooks/pre_gen_project.py``::
+
+
+    import re, sys
+
+    MODULE_REGEX = r'^[_a-zA-Z][_a-zA-Z0-9]+$'
+
+    module_name = '{{ cookiecutter.module_name }}'
+
+    if not re.match(MODULE_REGEX, module_name):
+        print('ERROR: %s is not a valid Python module name!' % module_name)
+
+        # exits with status 1 to indicate failure
+        sys.exit(1)
+
 
 User Config (0.7.0+)
 ----------------------

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -44,10 +44,13 @@ Example: Validating template variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Here is an example of script that validates a template variable
-before generating the project, to be used as ``hooks/pre_gen_project.py``::
+before generating the project, to be used as ``hooks/pre_gen_project.py``:
 
+.. code-block:: python
 
-    import re, sys
+    import re
+    import sys
+
 
     MODULE_REGEX = r'^[_a-zA-Z][_a-zA-Z0-9]+$'
 

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -36,9 +36,9 @@ on Windows) can be a quicker alternative.
 
 .. note::
     Make sure your hook scripts work in a robust manner. If a hook script fails
-    (that is, if it finishes with an exit status that is not ``0``), the
-    project generation will stop and the generated directory will be cleaned
-    up.
+    (that is, `if it finishes with a nonzero exit status
+    <https://docs.python.org/2/library/sys.html#sys.exit>`_), the project
+    generation will stop and the generated directory will be cleaned up.
 
 Example: Validating template variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -34,6 +34,12 @@ hooks, as these can be run on any platform. However, if you intend for your
 template to only be run on a single platform, a shell script (or `.bat` file
 on Windows) can be a quicker alternative.
 
+.. note::
+    Make sure your hook scripts work in a robust manner.  If a hook script
+    fails (that is, if it finishes with an exit status that is not one of
+    success), the project generation will stop and the generated directory will
+    be cleaned up.
+
 User Config (0.7.0+)
 ----------------------
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -11,8 +11,9 @@ Tests for `cookiecutter.hooks` module.
 import sys
 import os
 import stat
+import pytest
 
-from cookiecutter import hooks, utils
+from cookiecutter import hooks, utils, exceptions
 
 
 def make_test_repo(name):
@@ -166,3 +167,16 @@ class TestExternalHooks(object):
 
             hooks.run_hook('post_gen_project', tests_dir, {})
             assert os.path.isfile(os.path.join(tests_dir, 'shell_post.txt'))
+
+    def test_run_failing_hook(self):
+        hook_path = os.path.join(self.hooks_path, 'pre_gen_project.py')
+        tests_dir = os.path.join(self.repo_path, 'input{{hooks}}')
+
+        with open(hook_path, 'w') as f:
+            f.write("#!/usr/bin/env python\n")
+            f.write("import sys; sys.exit(1)\n")
+
+        with utils.work_in(self.repo_path):
+            with pytest.raises(exceptions.FailedHookException) as excinfo:
+                hooks.run_hook('pre_gen_project', tests_dir, {})
+            assert 'Hook script failed' in str(excinfo)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -179,4 +179,4 @@ class TestExternalHooks(object):
         with utils.work_in(self.repo_path):
             with pytest.raises(exceptions.FailedHookException) as excinfo:
                 hooks.run_hook('pre_gen_project', tests_dir, {})
-            assert 'Hook script failed' in str(excinfo)
+            assert 'Hook script failed' in str(excinfo.value)


### PR DESCRIPTION
Hey folks,

Would this be an adequate solution to address issue #464 ?

My use case is handling an invalid package name (see https://github.com/audreyr/cookiecutter-pypackage/issues/6)

This proposal will stop the project generation if the pre hook script returns with an exit status different from 0 (indicating success).

With this proposal, we'd be able to handle that case with a `pre_gen_project` hook script like:

```
import re, sys

PACKAGE_REGEX = r'^[_a-zA-Z][_a-zA-Z0-9]+$'

repo_name = '{{ cookiecutter.repo_name }}'
if not re.match(PACKAGE_REGEX, repo_name):
    print('ERROR: %s is not a valid package name!' % repo_name)
    sys.exit(1)
```

Thoughts?