### PR TITLE
Make tests work without installing cookiecutter

### DIFF
--- a/tests/test_cookiecutters.py
+++ b/tests/test_cookiecutters.py
@@ -12,6 +12,7 @@ TestJQuery.test_cookiecutter_jquery
 
 from __future__ import unicode_literals
 import os
+import sys
 import subprocess
 import pytest
 
@@ -37,14 +38,16 @@ def remove_additional_dirs(request):
 def bake_data():
     pypackage_data = (
         'git clone https://github.com/audreyr/cookiecutter-pypackage.git',
-        'cookiecutter --no-input cookiecutter-pypackage/',
+        '{0} -m cookiecutter.cli --no-input cookiecutter-pypackage/'.format(
+            sys.executable),
         'cookiecutter-pypackage',
         'boilerplate/README.rst'
     )
 
     jquery_data = (
         'git clone https://github.com/audreyr/cookiecutter-jquery.git',
-        'cookiecutter --no-input cookiecutter-jquery/',
+        '{0} -m cookiecutter.cli --no-input cookiecutter-jquery/'.format(
+            sys.executable),
         'cookiecutter-jquery',
         'boilerplate/README.md'
     )

--- a/tests/test_more_cookiecutters.py
+++ b/tests/test_more_cookiecutters.py
@@ -12,6 +12,7 @@ TestExamplesRepoArg.test_cookiecutter_pypackage_git
 
 from __future__ import unicode_literals
 import os
+import sys
 import subprocess
 import pytest
 
@@ -39,7 +40,8 @@ def remove_additional_dirs(request):
 def test_git_branch():
     pypackage_git = 'https://github.com/audreyr/cookiecutter-pypackage.git'
     proc = subprocess.Popen(
-        'cookiecutter -c console-script {0}'.format(pypackage_git),
+        '{0} -m cookiecutter.cli -c console-script {1}'.format(sys.executable,
+                                                               pypackage_git),
         stdin=subprocess.PIPE,
         shell=True
     )
@@ -56,7 +58,8 @@ def test_git_branch():
 @pytest.mark.usefixtures('clean_system', 'remove_additional_dirs')
 def test_cookiecutter_pypackage_git():
     proc = subprocess.Popen(
-        'cookiecutter https://github.com/audreyr/cookiecutter-pypackage.git',
+        '{0} -m cookiecutter.cli https://github.com/audreyr/'
+        'cookiecutter-pypackage.git'.format(sys.executable),
         stdin=subprocess.PIPE,
         shell=True
     )


### PR DESCRIPTION
When running tests without installing cookiecutter, some of them fail
because they try to invoke cookiecutter. Moreover, if cookiecutter is
installed on the system, the tests would use the installed version
instead of the one in the build tree.

To solve both issues, use `python -m cookiecutter.cli` instead of
`cookiecutter`.

I know that the official way of testing is using tox, but in some cases, tox is not usable because it requires a network access.