### PR TITLE
Problem: I am lazy to type github username/password

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -26,6 +26,7 @@ from .replay import dump, load
 logger = logging.getLogger(__name__)
 
 builtin_abbreviations = {
+    'ssh@gh': 'git@github.com:{0}.git',
     'gh': 'https://github.com/{0}.git',
     'bb': 'https://bitbucket.org/{0}',
 }


### PR DESCRIPTION
... or to remember lazy ssh url

Solution: add ssh@gh to the list of default abbreviations, which expands
to ssh url for github. cookiecutter ssh@gh:foo/bar no longer asks for
username or password.