### PR TITLE
Return rendered project dir

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -316,3 +316,5 @@ def generate_files(repo_dir, context=None, output_dir='.',
     # run post-gen hook from repo_dir
     with work_in(repo_dir):
         run_hook('post_gen_project', project_dir, context)
+
+    return project_dir

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -131,7 +131,7 @@ def cookiecutter(
         dump(template_name, context)
 
     # Create project from local context and project template.
-    generate_files(
+    return generate_files(
         repo_dir=repo_dir,
         context=context,
         overwrite_if_exists=overwrite_if_exists,

--- a/tests/test_cookiecutter_local_no_input.py
+++ b/tests/test_cookiecutter_local_no_input.py
@@ -80,4 +80,4 @@ def test_cookiecutter_templated_context():
 def test_cookiecutter_no_input_return_project_dir():
     """Call `cookiecutter()` with `no_input=True`."""
     project_dir = main.cookiecutter('tests/fake-repo-pre', no_input=True)
-    assert project_dir == 'fake-project'
+    assert project_dir == os.path.abspath('fake-project')

--- a/tests/test_cookiecutter_local_no_input.py
+++ b/tests/test_cookiecutter_local_no_input.py
@@ -74,3 +74,10 @@ def test_cookiecutter_templated_context():
         no_input=True
     )
     assert os.path.isdir('fake-project-templated')
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_additional_dirs')
+def test_cookiecutter_no_input_return_project_dir():
+    """Call `cookiecutter()` with `no_input=True`."""
+    project_dir = main.cookiecutter('tests/fake-repo-pre', no_input=True)
+    assert project_dir == 'fake-project'

--- a/tests/test_generate_files.py
+++ b/tests/test_generate_files.py
@@ -150,6 +150,19 @@ def test_generate_files_output_dir():
 
 
 @pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
+def test_return_rendered_project_dir():
+    os.mkdir('tests/custom_output_dir')
+    project_dir = generate.generate_files(
+        context={
+            'cookiecutter': {'food': 'pizzä'}
+        },
+        repo_dir=os.path.abspath('tests/test-generate-files'),
+        output_dir='tests/custom_output_dir'
+    )
+    assert project_dir == 'tests/custom_output_dir/inputpizzä/'
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
 def test_generate_files_permissions():
     """
     simple.txt and script.sh should retain their respective 0o644 and

--- a/tests/test_generate_files.py
+++ b/tests/test_generate_files.py
@@ -159,7 +159,9 @@ def test_return_rendered_project_dir():
         repo_dir=os.path.abspath('tests/test-generate-files'),
         output_dir='tests/custom_output_dir'
     )
-    assert project_dir == 'tests/custom_output_dir/inputpizzä/'
+    assert project_dir == os.path.abspath(
+        'tests/custom_output_dir/inputpizzä/'
+    )
 
 
 @pytest.mark.usefixtures('clean_system', 'remove_additional_folders')


### PR DESCRIPTION
This PR changes ``generate_files`` to return the rendered project directory instead of None.

By doing this we *(I am working on best-practices for template testing atm :squirrel:)* enable a caller to write tests in a convenient and yet simple way with minimal changes to **Cookiecutter** itself.

Please let me know your thoughts! :bow: 