### PR TITLE
WIP: add virtualenv util for hooks, so that templates can enable virtualenvs

### DIFF
--- a/cookiecutter/hooks.py
+++ b/cookiecutter/hooks.py
@@ -14,6 +14,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import virtualenv
 
 from jinja2 import Template
 
@@ -24,6 +25,23 @@ _HOOKS = [
     'post_gen_project',
     # TODO: other hooks should be listed here
 ]
+
+
+def setup_virtualenv(cwd='.', edit_mode=False):
+    """
+    Provide a way for templates to set up virtualenv automatically. Called
+    with the virtualenv path, which will usually be the template output
+    directory. If the edit_mode flag is True, will also run setup.py develop
+    to leave the project in edit mode.
+    """
+    virtualenv.create_environment(cwd)
+    if edit_mode:
+        proc = subprocess.Popen(
+            ['bin/python', 'setup.py', 'develop'],
+            shell=sys.platform.startswith('win'),
+            cwd=cwd
+        )
+        proc.wait()
 
 
 def find_hooks():

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ requirements = [
     'jinja2>=2.7',
     'PyYAML>=3.10',
     'click>=5.0',
-    'whichcraft>=0.1.1'
+    'whichcraft>=0.1.1',
+    'virtualenv>=13.1.2'
 ]
 
 long_description = readme + '\n\n' + history

--- a/tests/test-pyhooks/hooks/post_gen_project.py
+++ b/tests/test-pyhooks/hooks/post_gen_project.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function
+from cookiecutter.hooks import setup_virtualenv
 
 print('pre generation hook')
 f = open('python_post.txt', 'w')
 f.close()
+setup_virtualenv('./venv')

--- a/tests/test_generate_hooks.py
+++ b/tests/test_generate_hooks.py
@@ -60,6 +60,7 @@ def test_run_python_hooks():
     )
     assert os.path.exists('tests/test-pyhooks/inputpyhooks/python_pre.txt')
     assert os.path.exists('tests/test-pyhooks/inputpyhooks/python_post.txt')
+    assert os.path.exists('tests/test-pyhooks/inputpyhooks/venv/bin/python')
 
 
 @pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
@@ -72,6 +73,7 @@ def test_run_python_hooks_cwd():
     )
     assert os.path.exists('inputpyhooks/python_pre.txt')
     assert os.path.exists('inputpyhooks/python_post.txt')
+    assert os.path.exists('inputpyhooks/venv/bin/python')
 
 
 def make_test_repo(name):


### PR DESCRIPTION
The idea for this PR, is that cookiecutter can offer some utils that templates can use for executing some common post (or pre?) setup tasks with a minimum of work. Currently setting up virtualenvs is the only added hook utility.

The rationale for this is that templates can't require dependencies, so having code in a hook that depends on something gets much more difficult when there is no cookiecutter support. 

I can imagine having a small number of useful utilities like this to make life easier for template authors. The utils let the developer avoid repeating the same code in various templates. Unless they are needed, they sit harmlessly out of the way, except for required dependencies, which would get pulled when installing cookiecutter. This last thing could be considered a point against this approach.