### PR TITLE
Fix tests as per last changes in cookiecutter-pypackage

### DIFF
--- a/tests/test_cookiecutter_repo_arg.py
+++ b/tests/test_cookiecutter_repo_arg.py
@@ -26,8 +26,8 @@ def remove_additional_folders(request):
     def fin_remove_additional_folders():
         if os.path.isdir('cookiecutter-pypackage'):
             utils.rmtree('cookiecutter-pypackage')
-        if os.path.isdir('boilerplate'):
-            utils.rmtree('boilerplate')
+        if os.path.isdir('python_boilerplate'):
+            utils.rmtree('python_boilerplate')
         if os.path.isdir('cookiecutter-trytonmodule'):
             utils.rmtree('cookiecutter-trytonmodule')
         if os.path.isdir('module_name'):
@@ -42,15 +42,18 @@ def test_cookiecutter_git(monkeypatch):
         'cookiecutter.prompt.read_user_variable',
         lambda var, default: default
     )
-    main.cookiecutter('https://github.com/audreyr/cookiecutter-pypackage.git')
+    main.cookiecutter(
+        'https://github.com/audreyr/cookiecutter-pypackage.git',
+        no_input=True
+    )
     clone_dir = os.path.join(
         os.path.expanduser('~/.cookiecutters'),
         'cookiecutter-pypackage'
     )
     assert os.path.exists(clone_dir)
-    assert os.path.isdir('boilerplate')
-    assert os.path.isfile('boilerplate/README.rst')
-    assert os.path.exists('boilerplate/setup.py')
+    assert os.path.isdir('python_boilerplate')
+    assert os.path.isfile('python_boilerplate/README.rst')
+    assert os.path.exists('python_boilerplate/setup.py')
 
 
 @skipif_no_network

--- a/tests/test_cookiecutters.py
+++ b/tests/test_cookiecutters.py
@@ -25,12 +25,10 @@ def remove_additional_dirs(request):
     Remove special directories which are creating during the tests.
     """
     def fin_remove_additional_dirs():
-        if os.path.isdir('cookiecutter-pypackage'):
-            utils.rmtree('cookiecutter-pypackage')
-        if os.path.isdir('cookiecutter-jquery'):
-            utils.rmtree('cookiecutter-jquery')
-        if os.path.isdir('boilerplate'):
-            utils.rmtree('boilerplate')
+        for path in ('cookiecutter-pypackage', 'cookiecutter-jquery',
+                     'python_boilerplate', 'boilerplate'):
+            if os.path.isdir(path):
+                utils.rmtree(path)
     request.addfinalizer(fin_remove_additional_dirs)
 
 
@@ -39,7 +37,7 @@ def bake_data():
         'git clone https://github.com/audreyr/cookiecutter-pypackage.git',
         'cookiecutter --no-input cookiecutter-pypackage/',
         'cookiecutter-pypackage',
-        'boilerplate/README.rst'
+        'python_boilerplate/README.rst'
     )
 
     jquery_data = (

--- a/tests/test_more_cookiecutters.py
+++ b/tests/test_more_cookiecutters.py
@@ -30,6 +30,8 @@ def remove_additional_dirs(request):
                 utils.rmtree('cookiecutter-pypackage')
         if os.path.isdir('boilerplate'):
             utils.rmtree('boilerplate')
+        if os.path.isdir('python_boilerplate'):
+            utils.rmtree('python_boilerplate')
     request.addfinalizer(fin_remove_additional_dirs)
 
 
@@ -64,4 +66,4 @@ def test_cookiecutter_pypackage_git():
     # Just skip all the prompts
     proc.communicate(input=b'\n\n\n\n\n\n\n\n\n\n\n\n')
 
-    assert os.path.isfile('boilerplate/README.rst')
+    assert os.path.isfile('python_boilerplate/README.rst')


### PR DESCRIPTION
So, this fixes the tests depending on the the default project name of cookiecutter-pypackage in master -- which changed in the last few commits.