### PR TITLE
For #557, moves us mostly from PyYAML to raumel.yaml

### DIFF
--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -14,7 +14,10 @@ import logging
 import os
 import io
 
-import ruamel.yaml as yaml
+try:
+    import ruamel.yaml as yaml
+except ImportError:
+    import yaml
 
 from .exceptions import ConfigDoesNotExistException
 from .exceptions import InvalidConfiguration

--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -14,7 +14,7 @@ import logging
 import os
 import io
 
-import yaml
+import ruamel.yaml as yaml
 
 from .exceptions import ConfigDoesNotExistException
 from .exceptions import InvalidConfiguration

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import platform
 import sys
 
 try:
@@ -30,10 +31,17 @@ requirements = [
     'future>=0.15.2',
     'binaryornot>=0.2.0',
     'jinja2>=2.7',
-    'ruamel.yaml>=0.10.12',
     'click>=5.0',
     'whichcraft>=0.1.1'
 ]
+
+# Use PyYAML for 2.7 on Windows, ruamel.yaml everywhere else
+PY2 = sys.version_info[0] == 2
+windows = platform.system().lower().startswith('windows')
+if PY2 and windows:
+    requirements.append('PyYAML>=3.10')
+else:
+    requirements.append('ruamel.yaml>=0.10.12')
 
 long_description = readme + '\n\n' + history
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ requirements = [
     'future>=0.15.2',
     'binaryornot>=0.2.0',
     'jinja2>=2.7',
-    'PyYAML>=3.10',
+    'ruamel.yaml>=0.10.12',
     'click>=5.0',
     'whichcraft>=0.1.1'
 ]


### PR DESCRIPTION

Even if this passes Appveyor/Travis tests, please do not merge this in yet as we're still in the process of testing this fix across several local Windows machines.

To install via pip (for testers):

`pip install git+ssh://git@github.com/audreyr/cookiecutter.git@ruamel-yaml-557#egg=cookiecutter`
