### PR TITLE
Proposing improvements to workflow while updating docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -68,6 +68,14 @@ Cookiecutter could always use more documentation, whether as part of the
 official Cookiecutter docs, in docstrings, or even on the web in blog posts,
 articles, and such.
 
+If you want to review your changes on the documentation locally, you can do::
+
+    pip install -r docs/requirements.txt
+    make servedocs
+
+This will compile the documentation, open it in your browser and start
+watching the files for changes, recompiling as you save.
+
 Submit Feedback
 ~~~~~~~~~~~~~~~
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,15 @@
 .PHONY: clean-pyc clean-build docs
+define BROWSER_PYSCRIPT
+import os, webbrowser, sys
+try:
+	from urllib import pathname2url
+except:
+	from urllib.request import pathname2url
+
+webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+endef
+export BROWSER_PYSCRIPT
+BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
 help:
 	@echo "clean-build - remove build artifacts"
@@ -35,7 +46,7 @@ test-all:
 
 coverage:
 	tox -e cov-report
-	open htmlcov/index.html
+	$(BROWSER) htmlcov/index.html
 
 docs:
 	rm -f docs/cookiecutter.rst
@@ -44,7 +55,10 @@ docs:
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	make contributing
-	open docs/_build/html/index.html
+	$(BROWSER) docs/_build/html/index.html
+
+servedocs: docs
+	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
 
 release: clean
 	python setup.py sdist bdist_wheel upload

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -132,7 +132,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+watchdog==0.8.3
+sphinx-rtd-theme==0.1.9


### PR DESCRIPTION
I get annoyed when there is a too long feedback cycle between writing the docs and seeing the change applied. This PR is about fixing that. :)

Summary of changes:

* use ReadTheDocs theme to build the documentation locally, to make it look like it [the official one](http://cookiecutter.readthedocs.org/)
* add a `make servedocs` target that uses `watchmedo` (from watchdog) to watch for changes in the doc files and recompile as needed
* use portable way of opening browser (`open` is Mac-only and fails in my Linux box)
* add `docs/requirements.txt` with needed dependencies
* add note in contributing docs recommending this workflow

Does this look good?