### PR TITLE
Additional help entrypoints

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -75,6 +75,13 @@ def main(template, no_input, checkout, verbose, replay, overwrite_if_exists,
         )
 
     try:
+
+        # If you _need_ to support a local template in a directory
+        # called 'help', use a qualified path to the directory.
+        if template == u'help':
+            click.echo(click.get_current_context().get_help())
+            sys.exit(0)
+
         cookiecutter(
             template, checkout, no_input,
             replay=replay,

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -30,7 +30,7 @@ def version_msg():
     return message.format(location, python_version)
 
 
-@click.command()
+@click.command(context_settings=dict(help_option_names=[u'-h', u'--help']))
 @click.version_option(__version__, u'-V', u'--version', message=version_msg())
 @click.argument(u'template')
 @click.option(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -203,3 +203,14 @@ def test_cli_output_dir(mocker, output_dir_flag, output_dir):
         overwrite_if_exists=False,
         output_dir=output_dir
     )
+
+
+@pytest.fixture(params=['-h', '--help', 'help'])
+def help_cli_flag(request):
+    return request.param
+
+
+def test_cli_help(help_cli_flag):
+    result = runner.invoke(main, [help_cli_flag])
+    assert result.exit_code == 0
+    assert result.output.startswith('Usage')


### PR DESCRIPTION
Fixes #492.
Adds support for `cookiecutter -h` and `cookiecutter help`.
To address `cookiecutter` we'd need to override `click`'s validation of the required `template` argument.