### PR TITLE
Test x86 and x86-64 architectures on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,19 +6,31 @@ environment:
     - PYTHON: "C:\\Python27"
       TOX_ENV: "py27"
 
+    - PYTHON: "C:\\Python27-x64"
+      TOX_ENV: "py27"
+
     - PYTHON: "C:\\Python33"
+      TOX_ENV: "py33"
+
+    - PYTHON: "C:\\Python33-x64"
       TOX_ENV: "py33"
 
     - PYTHON: "C:\\Python34"
       TOX_ENV: "py34"
 
+    - PYTHON: "C:\\Python34-x64"
+      TOX_ENV: "py34"
+
     - PYTHON: "C:\\Python35"
+      TOX_ENV: "py35"
+
+    - PYTHON: "C:\\Python35-x64"
       TOX_ENV: "py35"
 
 
 init:
   - "%PYTHON%/python -V"
-  - "%PYTHON%/python -c \"import struct;print( 8 * struct.calcsize(\'P\'))\""
+  - "%PYTHON%/python -c \"import struct;print(8 * struct.calcsize(\'P\'))\""
 
 install:
   - "%PYTHON%/Scripts/easy_install -U pip"


### PR DESCRIPTION
This PR will make sure cookiecutter is tested against x86 and x86-64 architecture interpreters on appveyor. The idea was to catch problems if a dependency fails to install on either architecture, like #557. 

This only changes testing on appveyor, as I am not sure whether this is possible on travis-ci without installing the corresponding interpreter from source and without changing ``tox.ini``. 
Maybe someone has some insight on this, I am not sure I can have a look at it anytime soon. 

Does this make sense, or is it better to leave the current testing as it is, to make sure testing is identical on both buildservers? 

Should documentation be updated? 
