### PR TITLE
Drop yaml libs use custom parser

### DIFF
--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -14,13 +14,9 @@ import logging
 import os
 import io
 
-try:
-    import ruamel.yaml as yaml
-except ImportError:
-    import yaml
-
 from .exceptions import ConfigDoesNotExistException
 from .exceptions import InvalidConfiguration
+from . import config_parser
 
 
 logger = logging.getLogger(__name__)
@@ -43,16 +39,14 @@ def get_config(config_path):
     logger.debug('config_path is {0}'.format(config_path))
     with io.open(config_path, encoding='utf-8') as file_handle:
         try:
-            yaml_dict = yaml.safe_load(file_handle)
-        except yaml.scanner.ScannerError as e:
+            user_dict = config_parser.loads(file_handle.read())
+        except Exception as err:
             raise InvalidConfiguration(
-                '{0} is not a valid YAML file: line {1}: {2}'.format(
-                    config_path,
-                    e.problem_mark.line,
-                    e.problem))
+                '{} is not a valid config file: {}'.format(config_path, err)
+            )
 
     config_dict = copy.copy(DEFAULT_CONFIG)
-    config_dict.update(yaml_dict)
+    config_dict.update(user_dict)
 
     return config_dict
 

--- a/cookiecutter/config_parser.py
+++ b/cookiecutter/config_parser.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+import re
+
+VALUE = r"(?P<quotes>['\"]?)(?P<value>.*)(?P=quotes)$"
+SIMPLE = r"^(?P<variable>\w+): " + VALUE
+
+
+def find_simple(config_str):
+    """Find all matches for non-nested config variables in config_str.
+
+    Examples:
+        cookiecutters_dir: "/home/audreyr/my-custom-cookiecutters-dir/"
+        replay_dir: "/home/audreyr/my-custom-replay-dir/"
+    """
+    matches = re.findall(SIMPLE, config_str, re.MULTILINE)
+    return {variable: value for variable, quotes, value in matches}
+
+
+def loads(config_str):
+    """Deserialize the given config_str to a Python dict."""
+    config = {}
+    return config.update(find_simple(config_str))

--- a/cookiecutter/config_parser.py
+++ b/cookiecutter/config_parser.py
@@ -48,4 +48,8 @@ def loads(config_str):
     config = {}
     config.update(find_simple(config_str))
     config.update(find_nested(config_str))
+
+    if config_str and not config:
+        raise ValueError('Unable to find valid config values')
+
     return config

--- a/cookiecutter/config_parser.py
+++ b/cookiecutter/config_parser.py
@@ -5,6 +5,9 @@ import re
 VALUE = r"(?P<quotes>['\"]?)(?P<value>.*)(?P=quotes)$"
 SIMPLE = r"^(?P<variable>\w+): " + VALUE
 
+NESTED = r"^(?P<variable>\w+):\s((?:^\s.+$\n)+)"
+NESTED_VAR = r"^\s+(?P<variable>\w+): " + VALUE
+
 
 def find_simple(config_str):
     """Find all matches for non-nested config variables in config_str.
@@ -17,7 +20,32 @@ def find_simple(config_str):
     return {variable: value for variable, quotes, value in matches}
 
 
+def find_nested(config_str):
+    """Find all matches for nested config variables in config_str.
+
+    Examples:
+        default_context:
+            full_name: "Audrey Roy"
+            email: "audreyr@gmail.com"
+            github_username: "audreyr"
+        abbreviations:
+            pp: https://github.com/audreyr/cookiecutter-pypackage.git
+            gh: https://github.com/{0}.git
+            bb: https://bitbucket.org/{0}
+    """
+    config = {}
+    nested_variables = re.findall(NESTED, config_str, re.MULTILINE)
+
+    for variable, text in nested_variables:
+        matches = re.findall(NESTED_VAR, text, re.MULTILINE)
+        config[variable] = {key: value for key, quotes, value in matches}
+
+    return config
+
+
 def loads(config_str):
     """Deserialize the given config_str to a Python dict."""
     config = {}
-    return config.update(find_simple(config_str))
+    config.update(find_simple(config_str))
+    config.update(find_nested(config_str))
+    return config

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os
-import platform
 import sys
 
 try:
@@ -34,14 +33,6 @@ requirements = [
     'click>=5.0',
     'whichcraft>=0.1.1'
 ]
-
-# Use PyYAML for 2.7 on Windows, ruamel.yaml everywhere else
-PY2 = sys.version_info[0] == 2
-windows = platform.system().lower().startswith('windows')
-if PY2 and windows:
-    requirements.append('PyYAML>=3.10')
-else:
-    requirements.append('ruamel.yaml>=0.10.12')
 
 long_description = readme + '\n\n' + history
 

--- a/tests/test_parse_user_config.py
+++ b/tests/test_parse_user_config.py
@@ -49,3 +49,20 @@ def test_find_simple(user_config):
         'replay_dir': "/home/audreyr/my-custom-replay-dir/",
     }
     assert result == expected
+
+
+def test_find_nested(user_config):
+    result = config_parser.find_nested(user_config)
+    expected = {
+        'default_context': {
+            'full_name': 'Audrey Roy',
+            'email': 'audreyr@gmail.com',
+            'github_username': 'audreyr',
+        },
+        'abbreviations': {
+            'pp': "https://github.com/audreyr/cookiecutter-pypackage.git",
+            'gh': "https://github.com/{0}.git",
+            'bb': "https://bitbucket.org/{0}"
+        }
+    }
+    assert result == expected

--- a/tests/test_parse_user_config.py
+++ b/tests/test_parse_user_config.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from cookiecutter import config_parser
+
+
+@pytest.fixture
+def user_config():
+    return """default_context:
+    full_name: "Audrey Roy"
+    email: "audreyr@gmail.com"
+    github_username: "audreyr"
+cookiecutters_dir: "/home/audreyr/my-custom-cookiecutters-dir/"
+replay_dir: "/home/audreyr/my-custom-replay-dir/"
+abbreviations:
+    pp: https://github.com/audreyr/cookiecutter-pypackage.git
+    gh: https://github.com/{0}.git
+    bb: https://bitbucket.org/{0}
+"""
+
+
+@pytest.fixture
+def expected_config():
+    return {
+        'default_context': {
+            'full_name': 'Audrey Roy',
+            'email': 'audreyr@gmail.com',
+            'github_username': 'audreyr',
+        },
+        'cookiecutters_dir': "/home/audreyr/my-custom-cookiecutters-dir/",
+        'replay_dir': "/home/audreyr/my-custom-replay-dir/",
+        'abbreviations': {
+            'pp': "https://github.com/audreyr/cookiecutter-pypackage.git",
+            'gh': "https://github.com/{0}.git",
+            'bb': "https://bitbucket.org/{0}"
+        }
+    }
+
+
+def test_parse_config(user_config, expected_config):
+    assert config_parser.loads(user_config) == expected_config

--- a/tests/test_parse_user_config.py
+++ b/tests/test_parse_user_config.py
@@ -40,3 +40,12 @@ def expected_config():
 
 def test_parse_config(user_config, expected_config):
     assert config_parser.loads(user_config) == expected_config
+
+
+def test_find_simple(user_config):
+    result = config_parser.find_simple(user_config)
+    expected = {
+        'cookiecutters_dir': "/home/audreyr/my-custom-cookiecutters-dir/",
+        'replay_dir': "/home/audreyr/my-custom-replay-dir/",
+    }
+    assert result == expected


### PR DESCRIPTION
WIP :raised_hand:

Simple regex parser implementation for [user configs](https://cookiecutter.readthedocs.org/en/latest/advanced_usage.html#user-config-0-7-0) to replace **PyYAML AND ruamel.yaml**. Users on various platforms and Python versions seem to encounter various problems with both libs when installing **Cookiecutter**, which is a huge problem (see #557 :worried: ).

Please let me know your thoughts!

(Related to #568)