### PR TITLE
Set up bumpversion

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 current_version = 1.2.1
 commit = True
 tag = True
+tag_name = {new_version}
 [bumpversion:file:setup.py]
 [bumpversion:file:cookiecutter/__init__.py]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,10 @@
+[bumpversion]
+current_version = 1.2.1
+commit = True
+tag = True
+[bumpversion:file:setup.py]
+[bumpversion:file:cookiecutter/__init__.py]
+
 [flake8]
 ignore = E731
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,9 @@ current_version = 1.2.1
 commit = True
 tag = True
 tag_name = {new_version}
+
 [bumpversion:file:setup.py]
+
 [bumpversion:file:cookiecutter/__init__.py]
 
 [flake8]
@@ -11,3 +13,4 @@ ignore = E731
 
 [bdist_wheel]
 universal = 1
+


### PR DESCRIPTION
Enables us to use ``bumpversion minor`` to lower the risk of missing a version var. :relaxed: 