### PR TITLE
Allow hooks to run multiple files for each hook type.

### DIFF
--- a/cookiecutter/hooks.py
+++ b/cookiecutter/hooks.py
@@ -46,7 +46,12 @@ def find_hooks():
     for f in os.listdir(hooks_dir):
         basename = os.path.splitext(os.path.basename(f))[0]
         if basename in _HOOKS:
-            r[basename] = os.path.abspath(os.path.join(hooks_dir, f))
+            file_name = os.path.abspath(os.path.join(hooks_dir, f))
+
+            if basename in r:
+                r[basename].append(file_name)
+            else:
+                r[basename] = [file_name]
     return r
 
 
@@ -111,4 +116,6 @@ def run_hook(hook_name, project_dir, context):
     if script is None:
         logging.debug('No hooks found')
         return
-    run_script_with_context(script, project_dir, context)
+
+    for script_file in script:
+        run_script_with_context(script_file, project_dir, context)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -72,10 +72,10 @@ class TestFindHooks(object):
 
         with utils.work_in(self.repo_path):
             expected = {
-                'pre_gen_project': os.path.abspath('hooks/pre_gen_project.py'),
-                'post_gen_project': os.path.abspath(
+                'pre_gen_project': [os.path.abspath('hooks/pre_gen_project.py')],
+                'post_gen_project': [os.path.abspath(
                     os.path.join('hooks', self.post_hook)
-                ),
+                )],
             }
             assert expected == hooks.find_hooks()
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -72,7 +72,9 @@ class TestFindHooks(object):
 
         with utils.work_in(self.repo_path):
             expected = {
-                'pre_gen_project': [os.path.abspath('hooks/pre_gen_project.py')],
+                'pre_gen_project': [os.path.abspath(
+                    'hooks/pre_gen_project.py'
+                )],
                 'post_gen_project': [os.path.abspath(
                     os.path.join('hooks', self.post_hook)
                 )],


### PR DESCRIPTION
This pull request will allow a user to provide a hooks structure such as this:

```
hooks/
    pre_gen_project.py
    pre_gen_project.sh
```

and have both of those scripts run at the usual point at which a hook is run. This allows a user to combine different script types to achieve their desired project state.