### PR TITLE
Include unknown extra variables

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -56,7 +56,9 @@ def apply_overwrites_to_context(context, overwrite_context):
     """Modify the given context in place based on the overwrite_context."""
     for variable, overwrite in overwrite_context.items():
         if variable not in context:
-            # Do not include variables which are not used in the template
+            # Albeit not relevant for the template, set this variable to
+            # resemble ``dict.update()``
+            context[variable] = overwrite
             continue
 
         context_value = context[variable]

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -112,9 +112,9 @@ def generate_context(context_file='cookiecutter.json', default_context=None,
     # Overwrite context variable defaults with the default context from the
     # user's global config, if available
     if default_context:
-        apply_overwrites_to_context(obj, default_context)
+        apply_overwrites_to_context(obj, default_context, known_only=True)
     if extra_context:
-        apply_overwrites_to_context(obj, extra_context)
+        apply_overwrites_to_context(obj, extra_context, known_only=False)
 
     logging.debug('Context generated is {0}'.format(context))
     return context

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -56,8 +56,8 @@ def apply_overwrites_to_context(context, overwrite_context):
     """Modify the given context in place based on the overwrite_context."""
     for variable, overwrite in overwrite_context.items():
         if variable not in context:
-            # Albeit not relevant for the template, set this variable to
-            # resemble ``dict.update()``
+            # Add a new entry to the context dict for values that are not
+            # declared in context but required in the template itself
             context[variable] = overwrite
             continue
 

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -52,13 +52,14 @@ def copy_without_render(path, context):
     return False
 
 
-def apply_overwrites_to_context(context, overwrite_context):
+def apply_overwrites_to_context(context, overwrite_context, known_only=False):
     """Modify the given context in place based on the overwrite_context."""
     for variable, overwrite in overwrite_context.items():
         if variable not in context:
-            # Add a new entry to the context dict for values that are not
-            # declared in context but required in the template itself
-            context[variable] = overwrite
+            if not known_only:
+                # Add a new entry to the context dict for values that are not
+                # declared in context but required in the template itself
+                context[variable] = overwrite
             continue
 
         context_value = context[variable]

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -128,12 +128,14 @@ def test_choices(context_file, default_context, extra_context):
     config and the list as such is not changed to a single value.
     """
     expected_context = {
-        'choices_template': OrderedDict([
-            ('full_name', 'Raphael Pierzina'),
-            ('github_username', 'hackebrot'),
-            ('project_name', 'Kivy Project'),
-            ('repo_name', '{{cookiecutter.project_name|lower}}'),
-            ('orientation', ['landscape', 'all', 'portrait']),
+        "choices_template": OrderedDict([
+            ("full_name", "Raphael Pierzina"),
+            ("github_username", "hackebrot"),
+            ("project_name", "Kivy Project"),
+            ("repo_name", "{{cookiecutter.project_name|lower}}"),
+            ("orientation", ["landscape", "all", "portrait"]),
+            ("not_in_template", "foobar"),
+            ("also_not_in_template", "foobar2"),
         ])
     }
 

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -156,7 +156,6 @@ def test_choices(context_file, default_context, extra_context):
             ('project_name', 'Kivy Project'),
             ('repo_name', '{{cookiecutter.project_name|lower}}'),
             ('orientation', ['landscape', 'all', 'portrait']),
-            ('not_in_template', 'foobar'),
             ('also_not_in_template', 'foobar2'),
         ])
     }

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -73,11 +73,22 @@ def context_data():
         }
     )
 
+    context_with_unknown_default = (
+        {
+            'context_file': 'tests/test-generate-context/test.json',
+            'default_context': {'1': 3, 'not in json': 'foobar'}
+        },
+        {
+            'test': {'1': 3, 'some_key': 'some_val'}
+        }
+    )
+
     yield context
     yield context_with_default
     yield context_with_extra
     yield context_with_default_and_extra
     yield context_with_unknown_extra
+    yield context_with_unknown_default
 
 
 @pytest.mark.usefixtures('clean_system')

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -63,10 +63,21 @@ def context_data():
         }
     )
 
+    context_with_unknown_extra = (
+        {
+            'context_file': 'tests/test-generate-context/test.json',
+            'extra_context': {'1': 4, 'not in json': 'foobar'},
+        },
+        {
+            'test': {'1': 4, 'some_key': 'some_val', 'not in json': 'foobar'}
+        }
+    )
+
     yield context
     yield context_with_default
     yield context_with_extra
     yield context_with_default_and_extra
+    yield context_with_unknown_extra
 
 
 @pytest.mark.usefixtures('clean_system')

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -166,6 +166,17 @@ def test_apply_overwrites_does_include_unknown_variables(template_context):
     assert 'not in template' in template_context
 
 
+def test_apply_overwrites_does_not_include_unknown_variables_if_option_is_set(
+        template_context):
+    generate.apply_overwrites_to_context(
+        template_context,
+        {'not in template': 'foobar'},
+        known_only=True
+    )
+
+    assert 'not in template' not in template_context
+
+
 def test_apply_overwrites_sets_non_list_value(template_context):
     generate.apply_overwrites_to_context(
         template_context,

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -157,13 +157,13 @@ def template_context():
     ])
 
 
-def test_apply_overwrites_does_include_unused_variables(template_context):
+def test_apply_overwrites_does_include_unknown_variables(template_context):
     generate.apply_overwrites_to_context(
         template_context,
         {'not in template': 'foobar'}
     )
 
-    assert 'not in template' not in template_context
+    assert 'not in template' in template_context
 
 
 def test_apply_overwrites_sets_non_list_value(template_context):

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -128,14 +128,14 @@ def test_choices(context_file, default_context, extra_context):
     config and the list as such is not changed to a single value.
     """
     expected_context = {
-        "choices_template": OrderedDict([
-            ("full_name", "Raphael Pierzina"),
-            ("github_username", "hackebrot"),
-            ("project_name", "Kivy Project"),
-            ("repo_name", "{{cookiecutter.project_name|lower}}"),
-            ("orientation", ["landscape", "all", "portrait"]),
-            ("not_in_template", "foobar"),
-            ("also_not_in_template", "foobar2"),
+        'choices_template': OrderedDict([
+            ('full_name', 'Raphael Pierzina'),
+            ('github_username', 'hackebrot'),
+            ('project_name', 'Kivy Project'),
+            ('repo_name', '{{cookiecutter.project_name|lower}}'),
+            ('orientation', ['landscape', 'all', 'portrait']),
+            ('not_in_template', 'foobar'),
+            ('also_not_in_template', 'foobar2'),
         ])
     }
 


### PR DESCRIPTION
Address the **feature/bug** discussed in #571.

----

Variables which are not specified in **cookiecutter.json** are added to the context unless the according flag (``known_only=True``) is set for ``generate.apply_overwrites_to_context()``.

The rationale of 8f082981fdcb3d1138d2962de88622006070ae91 was to **not** prompt the user for variables which are not declared in **cookiecutter.json** but injected via default context, as the template most probably doesn't use them.

This is different for extra context though, as it needs to be specified on every single invocation of cookiecutter.

Feedback is greatly appreciated! Thanks :bow: 

cc @danielsamuels @pydanny

----

Imagine the following **cookiecutter.json**:

```json
{
    "github_username": "hackebrot",
    "plugin_name": "foobar"
}
```

A user config file **~/.cookiecutterrc**:

```
default_context:
    github_username: "pydanny"
    foo: "bar"
```
Now if we specify extra context using the Python API:

```python
extra_context = {
    'unknown_in_extra': 'helloworld'
}
```

The context will look as follows (before user cli overwrites):

```json
{
    "github_username": "pydanny",
    "plugin_name": "foobar",
    "unknown_in_extra": "helloworld"
}
```
Please note that the user will be prompted for ``unknown_in_extra``!