### PR TITLE
Extend and fix skipif markers

### DIFF
--- a/tests/skipif_markers.py
+++ b/tests/skipif_markers.py
@@ -20,6 +20,13 @@ else:
     travis = True
 
 try:
+    os.environ[u'APPVEYOR']
+except KeyError:
+    travis = False
+else:
+    travis = True
+
+try:
     os.environ[u'DISABLE_NETWORK_TESTS']
 except KeyError:
     no_network = False
@@ -28,6 +35,10 @@ else:
 
 skipif_travis = pytest.mark.skipif(
     travis, reason='Works locally with tox but fails on Travis.'
+)
+
+skipif_appveyor = pytest.mark.skipif(
+    appveyor, reason='Works locally with tox but fails on Appveyor.'
 )
 
 skipif_no_network = pytest.mark.skipif(

--- a/tests/skipif_markers.py
+++ b/tests/skipif_markers.py
@@ -13,21 +13,21 @@ import os
 
 
 try:
-    os.environ[u'TRAVIS']
+    os.environ['TRAVIS']
 except KeyError:
     travis = False
 else:
     travis = True
 
 try:
-    os.environ[u'APPVEYOR']
+    os.environ['APPVEYOR']
 except KeyError:
     appveyor = False
 else:
     appveyor = True
 
 try:
-    os.environ[u'DISABLE_NETWORK_TESTS']
+    os.environ['DISABLE_NETWORK_TESTS']
 except KeyError:
     no_network = False
 else:

--- a/tests/skipif_markers.py
+++ b/tests/skipif_markers.py
@@ -22,9 +22,9 @@ else:
 try:
     os.environ[u'APPVEYOR']
 except KeyError:
-    travis = False
+    appveyor = False
 else:
-    travis = True
+    appveyor = True
 
 try:
     os.environ[u'DISABLE_NETWORK_TESTS']

--- a/tests/test_cookiecutters.py
+++ b/tests/test_cookiecutters.py
@@ -17,7 +17,9 @@ import subprocess
 import pytest
 
 from cookiecutter import utils
-from tests.skipif_markers import skipif_travis, skipif_no_network
+from tests.skipif_markers import (
+    skipif_travis, skipif_appveyor, skipif_no_network
+)
 
 
 @pytest.fixture(scope='function')
@@ -55,6 +57,7 @@ def bake_data():
 
 
 @skipif_travis
+@skipif_appveyor
 @skipif_no_network
 @pytest.mark.usefixtures('clean_system', 'remove_additional_dirs')
 @pytest.mark.parametrize('git_cmd, bake_cmd, out_dir, readme', bake_data())

--- a/tests/test_more_cookiecutters.py
+++ b/tests/test_more_cookiecutters.py
@@ -17,7 +17,9 @@ import subprocess
 import pytest
 
 from cookiecutter import config, utils
-from tests.skipif_markers import skipif_travis, skipif_no_network
+from tests.skipif_markers import (
+    skipif_travis, skipif_appveyor, skipif_no_network
+)
 
 
 @pytest.fixture(scope='function')
@@ -37,6 +39,7 @@ def remove_additional_dirs(request):
 
 
 @skipif_travis
+@skipif_appveyor
 @skipif_no_network
 @pytest.mark.usefixtures('clean_system', 'remove_additional_dirs')
 def test_git_branch():
@@ -56,6 +59,7 @@ def test_git_branch():
 
 
 @skipif_travis
+@skipif_appveyor
 @skipif_no_network
 @pytest.mark.usefixtures('clean_system', 'remove_additional_dirs')
 def test_cookiecutter_pypackage_git():

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py27, py33, py34, py35, pypy, flake8
 
 [testenv]
-passenv = LC_ALL, LANG, HOME
+passenv = LC_ALL, LANG, HOME, APPVEYOR, TRAVIS
 commands = py.test --cov=cookiecutter {posargs:tests}
 deps = pytest
        pytest-cov


### PR DESCRIPTION
I noticed that travis runs all of the tests (and they pass!) although we use skipif markers to skip certain tests for CI.

This PR makes sure that the tox testenvs do get the system environment variables ``TRAVIS`` and ``APPVEYOR`` so that the skipifs work as expected.

This is related to #599 