### PR TITLE
add correct ca-bundle path to git

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ environment:
 
 
 init:
+  - "git config --system http.sslcainfo \"C:\\Program Files\\Git\\mingw64\\ssl\\certs\\ca-bundle.crt\""
   - "%PYTHON%/python -V"
   - "%PYTHON%/python -c \"import struct;print(8 * struct.calcsize(\'P\'))\""
 


### PR DESCRIPTION
fix #599 appveyor issues
When GIT is invoked within a new virtualenv
it fails as it cant find the correct ca-bundle.
To ensure it finds the right file we set the
configuration beforehand.