### PR TITLE
add documentation for choice variables

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -370,4 +370,4 @@ The resulting prompt changes and looks like::
   Choose from 1, 2, 3, 4 [1]:
 
 .. note::
-   Notice how the first (default) value in the choice list changed from ``1 - MIT`` to ``1 - Apache Software License 2.0``.
+   As you can see the order of the options changed from ``1 - MIT`` to ``1 - Apache Software License 2.0``. **Cookiecutter** takes the first value in the list as the default.

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -351,8 +351,6 @@ For example, a choice variable can be created in ``cookiecutter.json`` by using 
 
 By default, the first entry in the values list serves as default value in the prompt.
 
-The default value can be overwritten in ``.cookiecutterrc``.
-
 Setting the default ``license`` agreement to *Apache Software License 2.0* can be done using:
 
 .. code-block:: yaml
@@ -360,6 +358,8 @@ Setting the default ``license`` agreement to *Apache Software License 2.0* can b
    default_context:       
        license: "Apache Software License 2.0"  
 
+in the :ref:`user-config` file. 
+       
 The resulting prompt changes and looks like::
 
   Select license:

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -290,6 +290,8 @@ Command Line Options
 
 .. cc-command-line-options::
 
+.. _choice-variables:
+   
 Choice Variables (1.1+)
 -----------------------
 
@@ -298,6 +300,8 @@ the template renders things differently.
 
 Basic Usage
 ~~~~~~~~~~~
+
+Choice variables are regular key / value pairs, but with the value being a list of strings.
 
 For example, if you provide the follwing choice variable in your ``cookiecutter.json``::
 
@@ -325,27 +329,38 @@ can be used like this::
   {%- elif cookiecutter.license == "BSD-3" -%}
   # More possible license content here
 
-Cookiecutter is using `Jinja2 conditional expressions <http://jinja.pocoo.org/docs/dev/templates/#expressions>`_ to determine the correct license.
+Cookiecutter is using `Jinja2's if conditional expression <http://jinja.pocoo.org/docs/dev/templates/#if>`_ to determine the correct license.
 
+The created choice variable is still a regular Cookiecutter variable and can be used as::
+
+  License
+  -------
+
+  Distributed under the terms of the `{{cookiecutter.license}}`_ license,
+  
 Overwriting Default Choice Values
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Choice Variables can we overwritten using a :ref:`user-config` file.
+Choice Variables are overwritable using a :ref:`user-config` file.
 
-For example, if you use the following choice variable in ``cookiecutter.json``::
+For example, a choice variable can be created in ``cookiecutter.json`` by using a list as value::
 
    {
        "license": ["MIT", "BSD-3", "GNU GPL v3.0", "Apache Software License 2.0"]
    }
 
-setting the default ``license`` agreement to *Apache Software License 2.0* can be done using a ``.cookiecutterrc``:
+By default, the first entry in the values list serves as default value in the prompt.
+
+The default value can be overwritten in ``.cookiecutterrc``.
+
+Setting the default ``license`` agreement to *Apache Software License 2.0* can be done using:
 
 .. code-block:: yaml
 
    default_context:       
        license: "Apache Software License 2.0"  
 
-resulting in a changed prompt::
+The resulting prompt changes and looks like::
 
   Select license:
   1 - Apache Software License 2.0

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -62,7 +62,8 @@ before generating the project, to be used as ``hooks/pre_gen_project.py``:
         # exits with status 1 to indicate failure
         sys.exit(1)
 
-
+.. _user-config:
+	
 User Config (0.7.0+)
 ----------------------
 
@@ -289,4 +290,69 @@ Command Line Options
 
 .. cc-command-line-options::
 
+Choice Variables (1.1+)
+-----------------------
 
+Choice variables provide different choices when creating a project. Depending on an user's choice
+the template renders things differently.
+
+Basic Usage
+~~~~~~~~~~~
+
+For example, if you provide the follwing choice variable in your ``cookiecutter.json``::
+
+   {
+       "license": ["MIT", "BSD-3", "GNU GPL v3.0", "Apache Software License 2.0"]
+   }
+
+you'd get the following choices when running Cookiecutter::
+
+   Select license:
+   1 - MIT
+   2 - BSD-3
+   3 - GNU GPL v3.0
+   4 - Apache Software License 2.0
+   Choose from 1, 2, 3, 4 [1]:		
+
+Depending on an user's choice, a different license is rendered by Cookiecutter. 
+
+The above ``license`` choice variable creates ``cookiecutter.license``, which
+can be used like this::
+
+  {%- if cookiecutter.license == "MIT" -%}
+  # Possible license content here
+  
+  {%- elif cookiecutter.license == "BSD-3" -%}
+  # More possible license content here
+
+Cookiecutter is using `Jinja2 conditional expressions <http://jinja.pocoo.org/docs/dev/templates/#expressions>`_ to determine the correct license.
+
+Overwriting Default Choice Values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Choice Variables can we overwritten using a :ref:`user-config` file.
+
+For example, if you use the following choice variable in ``cookiecutter.json``::
+
+   {
+       "license": ["MIT", "BSD-3", "GNU GPL v3.0", "Apache Software License 2.0"]
+   }
+
+setting the default ``license`` agreement to *Apache Software License 2.0* can be done using a ``.cookiecutterrc``:
+
+.. code-block:: yaml
+
+   default_context:       
+       license: "Apache Software License 2.0"  
+
+resulting in a changed prompt::
+
+  Select license:
+  1 - Apache Software License 2.0
+  2 - MIT
+  3 - BSD-3
+  4 - GNU GPL v3.0
+  Choose from 1, 2, 3, 4 [1]:
+
+.. note::
+   Notice how the first (default) value in the choice list changed from ``1 - MIT`` to ``1 - Apache Software License 2.0``.

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -331,7 +331,7 @@ can be used like this::
 
 Cookiecutter is using `Jinja2's if conditional expression <http://jinja.pocoo.org/docs/dev/templates/#if>`_ to determine the correct license.
 
-The created choice variable is still a regular Cookiecutter variable and can be used as::
+The created choice variable is still a regular Cookiecutter variable and can be used like this::
 
   License
   -------


### PR DESCRIPTION
The documentation follows the following outline (#600):

* basic usage describing how to use choice variables in templates
* providing default values using `.cookiecutterrc`