### PR TITLE
Add cookiecutter-python to the list of templates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,6 +152,9 @@ Python
 ~~~~~~
 * `cookiecutter-pypackage`_: `@audreyr`_'s ultimate Python package project
   template.
+* `cookiecutter-python`_: The boilerplate Python project that aims to create
+  facility for maintaining of the package easily. It considering tools for
+  building, testing and distribution.
 * `cookiecutter-flask`_ : A Flask template with Bootstrap 3, starter templates, and working user registration.
 * `cookiecutter-flask-foundation`_ : Flask Template with caching, forms, sqlalchemy and unit-testing.
 * `cookiecutter-bottle`_ : A cookiecutter template for creating reusable Bottle projects quickly.
@@ -239,6 +242,7 @@ HTML
 * `cookiecutter-tumblr-theme`_: A cookiecutter for a Tumblr theme project with GruntJS as concatination tool.
 
 .. _`cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
+.. _`cookiecutter-python`: https://github.com/flyondrag/cookiecutter-python
 .. _`cookiecutter-jquery`: https://github.com/audreyr/cookiecutter-jquery
 .. _`cookiecutter-flask`: https://github.com/sloria/cookiecutter-flask
 .. _`cookiecutter-flask-foundation`: https://github.com/JackStouffer/cookiecutter-Flask-Foundation


### PR DESCRIPTION
I have done with the new template for the Cookiecutter:

It comes with the number of useful features (implemented via Makefile facility):

* Management of Python virtual environments within the project:
  - Set up which versions of Python interpreter will be used for the project
  - Set up how a virtual environments will be created
  - Prepare an environments according to requirement files

* Support of the development lifecycle:
  - Work with sources in "development mode"
  - Test the project with Pytest
  - Build the distribution package (either in wheel of tarball formats)
  - Clean the project's directory in a Makefile-flavour::

* Issuing of the project's documentation using Sphinx:
  - Render documentation as a single PDF document

* Debian packaging
  - Configure most valuable parameters for a Debian packaging system via Makefile variables
  - Build a Debian package containing an isolated virtual environment with installed project and all of the project's requirements
  - Build a Debian package containing a prefix-based installation of the
project