### PR TITLE
set path before running tox

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ environment:
 
 
 init:
+  - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
   - "git config --system http.sslcainfo \"C:\\Program Files\\Git\\mingw64\\ssl\\certs\\ca-bundle.crt\""
   - "%PYTHON%/python -V"
   - "%PYTHON%/python -c \"import struct;print(8 * struct.calcsize(\'P\'))\""


### PR DESCRIPTION
This should fix the problem described in #615.
The default interpreter should be the one used to run Tox (https://tox.readthedocs.org/en/latest/config.html?highlight=interpreter#confval-basepython=NAME-OR-PATH) but to be sure, set PATH to contain the correct interpreter. On Windows Tox also searches there (https://github.com/msabramo/tox/blob/master/tox/interpreters.py#L121). 