### PR TITLE
Use poyo for user rc files

### DIFF
--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -14,10 +14,7 @@ import logging
 import os
 import io
 
-try:
-    import ruamel.yaml as yaml
-except ImportError:
-    import yaml
+import poyo
 
 from .exceptions import ConfigDoesNotExistException
 from .exceptions import InvalidConfiguration
@@ -45,13 +42,12 @@ def get_config(config_path):
     logger.debug('config_path is {0}'.format(config_path))
     with io.open(config_path, encoding='utf-8') as file_handle:
         try:
-            yaml_dict = yaml.safe_load(file_handle)
-        except yaml.scanner.ScannerError as e:
+            yaml_dict = poyo.parse_string(file_handle.read())
+        except poyo.exceptions.PoyoException as e:
             raise InvalidConfiguration(
-                '{0} is not a valid YAML file: line {1}: {2}'.format(
-                    config_path,
-                    e.problem_mark.line,
-                    e.problem))
+                'Unable to parse YAML file {}. Error: {}'
+                ''.format(config_path, e)
+            )
 
     config_dict = copy.copy(DEFAULT_CONFIG)
     config_dict.update(yaml_dict)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ requirements = [
     'binaryornot>=0.2.0',
     'jinja2>=2.7',
     'click>=5.0',
-    'whichcraft>=0.1.1'
+    'whichcraft>=0.1.1',
+    'poyo>=0.1.0'
 ]
 
 long_description = readme + '\n\n' + history
@@ -59,14 +60,6 @@ setup(
     },
     include_package_data=True,
     install_requires=requirements,
-    extras_require={
-        ':sys_platform=="win32" and python_version=="2.7"': [
-            'PyYAML>=3.10'
-        ],
-        ':sys_platform!="win32" or python_version!="2.7"': [
-            'ruamel.yaml>=0.10.12'
-        ]
-    },
     license='BSD',
     zip_safe=False,
     classifiers=[

--- a/tests/test_get_config.py
+++ b/tests/test_get_config.py
@@ -55,10 +55,11 @@ def test_invalid_config():
         config.get_config('tests/test-config/invalid-config.yaml')
 
     expected_error_msg = (
-        'tests/test-config/invalid-config.yaml is not a valid YAML file: '
-        'line 1: mapping values are not allowed here'
+        'Unable to parse YAML file '
+        'tests/test-config/invalid-config.yaml. '
+        'Error: '
     )
-    assert str(excinfo.value) == expected_error_msg
+    assert expected_error_msg in str(excinfo.value)
 
 
 def test_get_config_with_defaults():

--- a/tests/test_get_user_config.py
+++ b/tests/test_get_user_config.py
@@ -98,24 +98,19 @@ def test_get_user_config_nonexistent():
 @pytest.fixture
 def custom_config():
     return {
-        'cookiecutters_dir': '/foo/bar/some-path-to-templates',
-        'replay_dir': '/foo/bar/some-path-to-replay-files',
         'default_context': {
-            'full_name': 'Cookiemonster',
-            'github_username': 'hackebrot'
+            'full_name': 'Firstname Lastname',
+            'email': 'firstname.lastname@gmail.com',
+            'github_username': 'example',
         },
-        'abbreviations': {
-            'cookiedozer': 'https://github.com/hackebrot/cookiedozer.git',
-        }
+        'cookiecutters_dir': '/home/example/some-path-to-templates',
+        'replay_dir': '/home/example/some-path-to-replay-files'
     }
 
 
 @pytest.fixture
-def custom_config_path(tmpdir, custom_config):
-    user_config_file = tmpdir.join('user_config')
-
-    user_config_file.write(config.yaml.dump(custom_config))
-    return str(user_config_file)
+def custom_config_path(custom_config):
+    return 'tests/test-config/valid-config.yaml'
 
 
 def test_specify_config_path(mocker, custom_config_path, custom_config):


### PR DESCRIPTION
I wrote a YAML parser for simple files. :chicken: 

https://pypi.python.org/pypi/poyo

It should be fine for ``cookiecutterrc`` files and may help us overcome the troubles with **PyYAML** and **ruamel.yaml** (#557, #569). :worried: 