### PR TITLE
Add jinja2 time

### DIFF
--- a/cookiecutter/environment.py
+++ b/cookiecutter/environment.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from jinja2 import Environment, StrictUndefined
+
+
+class StrictEnvironment(Environment):
+    """Jinja2 environment that raises an error when it hits a variable
+    which is not defined in the context used to render a template.
+    """
+    def __init__(self, **kwargs):
+        super(StrictEnvironment, self).__init__(
+            undefined=StrictUndefined,
+            extensions=['jinja2_time.TimeExtension'],
+            **kwargs
+        )

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -16,8 +16,8 @@ import logging
 import os
 import shutil
 
-from jinja2 import FileSystemLoader, StrictUndefined
-from jinja2.environment import Environment
+from jinja2 import FileSystemLoader
+from cookiecutter.environment import StrictEnvironment
 from jinja2.exceptions import TemplateSyntaxError, UndefinedError
 from binaryornot.check import is_binary
 
@@ -256,10 +256,7 @@ def generate_files(repo_dir, context=None, output_dir='.',
 
     unrendered_dir = os.path.split(template_dir)[1]
     ensure_dir_is_templated(unrendered_dir)
-    env = Environment(
-        keep_trailing_newline=True,
-        undefined=StrictUndefined
-    )
+    env = StrictEnvironment(keep_trailing_newline=True)
     try:
         project_dir = render_and_create_dir(
             unrendered_dir,

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -15,11 +15,10 @@ from past.builtins import basestring
 
 from future.utils import iteritems
 
-from jinja2 import StrictUndefined
-from jinja2.environment import Environment
 from jinja2.exceptions import UndefinedError
 
 from .exceptions import UndefinedVariableInTemplate
+from .environment import StrictEnvironment
 
 
 def read_user_variable(var_name, default_value):
@@ -117,7 +116,7 @@ def prompt_for_config(context, no_input=False):
     :param no_input: Prompt the user at command line for manual configuration?
     """
     cookiecutter_dict = {}
-    env = Environment(undefined=StrictUndefined)
+    env = StrictEnvironment()
 
     for key, raw in iteritems(context[u'cookiecutter']):
         if key.startswith(u'_'):

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ requirements = [
     'jinja2>=2.7',
     'click>=5.0',
     'whichcraft>=0.1.1',
-    'poyo>=0.1.0'
+    'poyo>=0.1.0',
+    'jinja2-time>=0.1.0'
 ]
 
 long_description = readme + '\n\n' + history

--- a/tests/test-extensions/cookiecutter.json
+++ b/tests/test-extensions/cookiecutter.json
@@ -1,0 +1,5 @@
+{
+    "project_slug": "Foobar",
+    "year": "{% now 'utc', '%Y' %}"
+}
+

--- a/tests/test-extensions/{{cookiecutter.project_slug}}/HISTORY.rst
+++ b/tests/test-extensions/{{cookiecutter.project_slug}}/HISTORY.rst
@@ -1,0 +1,7 @@
+History {{cookiecutter.year}}
+------------
+
+0.1.0 ({% now 'utc', '%Y-%m-%d' %})
+---------------------
+
+First release on PyPI.

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+import os
+import io
+
+import pytest
+import freezegun
+
+from cookiecutter.main import cookiecutter
+
+
+@pytest.yield_fixture(autouse=True)
+def freeze():
+    freezer = freezegun.freeze_time("2015-12-09 23:33:01")
+    freezer.start()
+    yield
+    freezer.stop()
+
+
+def test_extensions(tmpdir):
+    project_dir = cookiecutter(
+        'tests/test-extensions/',
+        no_input=True,
+        output_dir=str(tmpdir)
+    )
+    changelog_file = os.path.join(project_dir, 'HISTORY.rst')
+    assert os.path.isfile(changelog_file)
+
+    with io.open(changelog_file, 'r', encoding='utf-8') as f:
+        changelog_lines = f.readlines()
+
+    expected_lines = [
+        'History 2015\n',
+        '------------\n',
+        '\n',
+        '0.1.0 (2015-12-09)\n',
+        '---------------------\n',
+        '\n',
+        'First release on PyPI.\n'
+    ]
+    assert expected_lines == changelog_lines

--- a/tests/test_generate_file.py
+++ b/tests/test_generate_file.py
@@ -15,10 +15,10 @@ import os
 import pytest
 
 from jinja2 import FileSystemLoader
-from jinja2.environment import Environment
 from jinja2.exceptions import TemplateSyntaxError
 
 from cookiecutter import generate
+from cookiecutter.environment import StrictEnvironment
 
 
 @pytest.fixture(scope='function')
@@ -34,7 +34,7 @@ def remove_cheese_file(request):
 
 @pytest.fixture
 def env():
-    environment = Environment()
+    environment = StrictEnvironment()
     environment.loader = FileSystemLoader('.')
     return environment
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -14,8 +14,7 @@ import platform
 import pytest
 from past.builtins import basestring
 
-from cookiecutter import prompt, exceptions
-from jinja2.environment import Environment
+from cookiecutter import prompt, exceptions, environment
 
 
 @pytest.mark.parametrize('raw_var, rendered_var', [
@@ -26,9 +25,9 @@ from jinja2.environment import Environment
     (None, None),
 ])
 def test_convert_to_str(mocker, raw_var, rendered_var):
-    env = Environment()
+    env = environment.StrictEnvironment()
     from_string = mocker.patch(
-        'cookiecutter.prompt.Environment.from_string',
+        'cookiecutter.prompt.StrictEnvironment.from_string',
         wraps=env.from_string
     )
     context = {'project': 'foobar'}
@@ -228,7 +227,7 @@ class TestPromptChoiceForConfig(object):
 
         actual_choice = prompt.prompt_choice_for_config(
             context,
-            Environment(),
+            environment.StrictEnvironment(),
             'orientation',
             choices,
             True  # Suppress user input
@@ -244,7 +243,7 @@ class TestPromptChoiceForConfig(object):
 
         actual_choice = prompt.prompt_choice_for_config(
             context,
-            Environment(),
+            environment.StrictEnvironment(),
             'orientation',
             choices,
             False  # Ask the user for input

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ commands = py.test --cov=cookiecutter {posargs:tests}
 deps = pytest
        pytest-cov
        pytest-mock
+       freezegun
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
Support for current date time in prompt and generation via ``{% now 'utc' %}``.

Please let me know your thoughts! :bow: 

Related to #617 