### PR TITLE
Explicitly set encoding for reading history file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ if sys.argv[-1] == 'tag':
 with open('README.rst') as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst') as history_file:
+with open('HISTORY.rst', encoding="utf-8") as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 requirements = [


### PR DESCRIPTION
Fixes build in C locale. Otherwise I see:

Traceback (most recent call last):
  File "setup.py", line 24, in <module>
    history = history_file.read().replace('.. :changelog:', '')
  File "/usr/pkg/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 6348: ordinal not in range(128)