### PR TITLE
don't remove project directory on failed hook w/ --overwrite-if-exists

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -224,7 +224,8 @@ def ensure_dir_is_templated(dirname):
         raise NonTemplatedInputDirException
 
 
-def _run_hook_from_repo_dir(repo_dir, hook_name, project_dir, context):
+def _run_hook_from_repo_dir(repo_dir, hook_name, project_dir, context,
+                            overwrite_if_exists):
     """
     Run hook from repo directory, cleaning up project directory if hook fails
     """
@@ -232,9 +233,12 @@ def _run_hook_from_repo_dir(repo_dir, hook_name, project_dir, context):
         try:
             run_hook(hook_name, project_dir, context)
         except FailedHookException:
-            rmtree(project_dir)
             logging.error("Stopping generation because %s"
                           " hook script didn't exit successfully" % hook_name)
+            # If directory exists, it's better to leave the directory partially
+            # generated than to remove everything.
+            if not overwrite_if_exists:
+                rmtree(project_dir)
             raise
 
 
@@ -282,7 +286,8 @@ def generate_files(repo_dir, context=None, output_dir='.',
     project_dir = os.path.abspath(project_dir)
     logging.debug('project_dir is {0}'.format(project_dir))
 
-    _run_hook_from_repo_dir(repo_dir, 'pre_gen_project', project_dir, context)
+    _run_hook_from_repo_dir(repo_dir, 'pre_gen_project', project_dir, context,
+                            overwrite_if_exists)
 
     with work_in(template_dir):
         env.loader = FileSystemLoader('.')
@@ -353,6 +358,7 @@ def generate_files(repo_dir, context=None, output_dir='.',
                     msg = "Unable to create file '{}'".format(infile)
                     raise UndefinedVariableInTemplate(msg, err, context)
 
-    _run_hook_from_repo_dir(repo_dir, 'post_gen_project', project_dir, context)
+    _run_hook_from_repo_dir(repo_dir, 'post_gen_project', project_dir, context,
+                            overwrite_if_exists)
 
     return project_dir


### PR DESCRIPTION
fixes audreyr/cookiecutter#629

Rough draft.  Let me know if you don't like this approach for any reason.

No tests for this change.  I looked at the current tests and didn't see anything test_hooks.py that was checking cleanup functionality.  Is that where the tests for this should go?
