### PR TITLE
Pin codecov dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ install:
 after_success:
     # Report coverage results to codecov.io
     # and export tox environment variables
-    - pip install codecov
+    - "pip install codecov==1.6.3"
     - codecov -e TOX_ENV TRAVIS_OS_NAME

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,7 +51,7 @@ after_test:
 on_success:
     # Report coverage results to codecov.io
     # and export tox environment variables
-    - "%PYTHON%/Scripts/pip install codecov"
+    - "%PYTHON%/Scripts/pip install codecov==1.6.3"
     - set OS=WINDOWS
     - "%PYTHON%/Scripts/codecov -e TOX_ENV OS"
 


### PR DESCRIPTION
The latest codecov releases introduce PyYAML as a dependency, which [fails to install on Appveyor (py33 and py34).](https://ci.appveyor.com/project/audreyr/cookiecutter/build/1.0.993/job/o3gey6aarbajrjvi)