### PR TITLE
added cookiecutter-snakemake-analysis-pipeline to list of cookiecutters.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -312,6 +312,7 @@ Python
 * `cookiecutter-python-app`_: A template to create a Python CLI application with subcommands, logging, YAML configuration, pytest tests, and Virtualenv deployment.
 * `morepath-cookiecutter`_: Cookiecutter template for Morepath, the web microframework with superpowers.
 * `Springerle/hovercraft-slides`_: A template for new `Hovercraft!`_ presentation projects (``impress.js`` slides in *re*\ Structured\ *Text*).
+* `cookiecutter-snakemake-analysis-pipeline`_: One way to easily set up `Snakemake`_-based analysis pipelines.
 
 .. _`cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
 .. _`cookiecutter-pipproject`: https://github.com/wdm0006/cookiecutter-pipproject
@@ -346,6 +347,8 @@ Python
 .. _`funkload-friendly`: https://github.com/tokibito/funkload-friendly
 .. _`cookiecutter-python-app`: https://github.com/mdklatt/cookiecutter-python-app
 .. _`morepath-cookiecutter`: https://github.com/morepath/morepath-cookiecutter
+.. _`cookiecutter-snakemake-analysis-pipeline`: https://github.com/xguse/cookiecutter-snakemake-analysis-pipeline
+.. _`Snakemake`: https://bitbucket.org/snakemake/snakemake/wiki/Home
 
 
 Python-Django


### PR DESCRIPTION
Not sure this is the right branch to PR to.  It just adds a cookiecutter for setting up Snakemake analysis pipelines that I have been using for a while.