### PR TITLE
Add a sprint contributor doc

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ Project Info
 
    contributing
    authors
+   sprint-contributors
    history
 
 Index

--- a/docs/sprint-contributors.rst
+++ b/docs/sprint-contributors.rst
@@ -1,0 +1,42 @@
+===================
+Sprint Contributors
+===================
+
+PyCon 2016 Sprint
+-----------------
+
+The following people made contributions to the cookiecutter project
+at the PyCon sprints in Portland, OR from June 2-5 2016. 
+Contributions include user testing, debugging, improving documentation, 
+reviewing issues, writing tutorials, creating and updating project
+templates, and teaching each other.
+
+
+
+* Audrey Roy Greenfeld (`@audreyr`_)
+* Carol Willing (`@willingc`_)
+* Christopher Clarke (`@chrisdev`_)
+* Daniel Roy Greenfeld (`@pydanny`_)
+* Emily Cain (`@emcain`_)
+* Phoebe Bauer (`@phoebebauer`_)
+* Kartik Sundararajan (`@skarbod`_)
+* Leonardo Jimenez (`@xpostudio4`_)
+* Meghan Heintz (`@dot2dotseurat`_)
+* Umair Ashraf (`@umrashrf`_)
+* Valdir Stumm Junior (`@stummjr`_)
+* Vivian Guillen (`@viviangb`_)
+
+
+.. _`@audreyr`: https://github.com/audreyr
+.. _`@willingc`: https://github.com/willingc
+.. _`@chrisdev`: https://github.com/chrisdev
+.. _`@pydanny`: https://github.com/pydanny
+.. _`@emcain`: https://github.com/emcain
+.. _`@phoebebauer`: https://github.com/phoebebauer
+.. _`@skarbod`: https://github.com/skarbod
+.. _`@xpostudio4`: https://github.com/xpostudio4
+.. _`@dot2dotseurat`: https://github.com/dot2dotseurat
+.. _`@umrashrf`: https://github.com/umrashrf
+.. _`@stummjr`: https://github.com/stummjr
+.. _`@viviangb`: https://github.com/viviangb
+

--- a/docs/sprint-contributors.rst
+++ b/docs/sprint-contributors.rst
@@ -11,32 +11,56 @@ Contributions include user testing, debugging, improving documentation,
 reviewing issues, writing tutorials, creating and updating project
 templates, and teaching each other.
 
-
-
+* Adam Chainz (`@adamchainz`_)
+* Andrew Ittner (`@tephyr`_)
 * Audrey Roy Greenfeld (`@audreyr`_)
 * Carol Willing (`@willingc`_)
 * Christopher Clarke (`@chrisdev`_)
+* Citlalli Murillo (`@citmusa`_)
 * Daniel Roy Greenfeld (`@pydanny`_)
+* Diane DeMers Chen (`@purplediane`_)
+* Elaine Wong (`@elainewong`_)
+* Elias Dorneles (`@eliasdorneles`_)
 * Emily Cain (`@emcain`_)
+* John Roa (`@jhonjairoroa87`_)
+* Jonan Scheffler (`@1337807`_)
 * Phoebe Bauer (`@phoebebauer`_)
-* Kartik Sundararajan (`@skarbod`_)
+* Kartik Sundararajan (`@skarbot`_)
+* Katia Lira (`@katialira`_)
 * Leonardo Jimenez (`@xpostudio4`_)
+* Lindsay Slazakowski (`@lslaz1`_)
 * Meghan Heintz (`@dot2dotseurat`_)
+* Raphael Pierzina (`@hackebrot`_)
 * Umair Ashraf (`@umrashrf`_)
 * Valdir Stumm Junior (`@stummjr`_)
 * Vivian Guillen (`@viviangb`_)
+* Zaro (`@zaro0508`_)
 
 
+
+
+.. _`@1337807`: https://github.com/1337807
+.. _`@adamchainz`: https://github.com/adamchainz
 .. _`@audreyr`: https://github.com/audreyr
-.. _`@willingc`: https://github.com/willingc
 .. _`@chrisdev`: https://github.com/chrisdev
-.. _`@pydanny`: https://github.com/pydanny
-.. _`@emcain`: https://github.com/emcain
-.. _`@phoebebauer`: https://github.com/phoebebauer
-.. _`@skarbod`: https://github.com/skarbod
-.. _`@xpostudio4`: https://github.com/xpostudio4
+.. _`@citmusa`: https://github.com/citmusa
 .. _`@dot2dotseurat`: https://github.com/dot2dotseurat
-.. _`@umrashrf`: https://github.com/umrashrf
+.. _`@elainewong`: https://github.com/elainewong
+.. _`@eliasdorneles`: https://github.com/eliasdorneles
+.. _`@emcain`: https://github.com/emcain
+.. _`@hackebrot`: https://github.com/hackebrot
+.. _`@jhonjairoroa87`: https://github.com/jhonjairoroa87
+.. _`@katialira`: https://github.com/katialira
+.. _`@lslaz1`: https://github.com/lslaz1
+.. _`@phoebebauer`: https://github.com/phoebebauer
+.. _`@purplediane`: https://github.com/purplediane
+.. _`@pydanny`: https://github.com/pydanny
+.. _`@skarbot`: https://github.com/skarbot
 .. _`@stummjr`: https://github.com/stummjr
+.. _`@tephyr`: https://github.com/tephyr
+.. _`@umrashrf`: https://github.com/umrashrf
 .. _`@viviangb`: https://github.com/viviangb
+.. _`@willingc`: https://github.com/willingc
+.. _`@xpostudio4`: https://github.com/xpostudio4
+.. _`@zaro0508`: https://github.com/zaro0508
 


### PR DESCRIPTION
Closes #719 

Creates a document acknowledging individuals who participated in the 2016 PyCon sprints, and adds this doc to the index