### PR TITLE
Update overview, tutorials, advanced usage -- change occurrences of 'repo_name'

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -11,7 +11,7 @@ is generated.
 Put them in `hooks/` like this::
 
     cookiecutter-something/
-    ├── {{cookiecutter.repo_name}}/
+    ├── {{cookiecutter.project_slug}}/
     ├── hooks
     │   ├── pre_gen_project.py
     │   └── post_gen_project.py
@@ -20,7 +20,7 @@ Put them in `hooks/` like this::
 Shell scripts work similarly::
 
     cookiecutter-something/
-    ├── {{cookiecutter.repo_name}}/
+    ├── {{cookiecutter.project_slug}}/
     ├── hooks
     │   ├── pre_gen_project.sh
     │   └── post_gen_project.sh
@@ -63,7 +63,7 @@ before generating the project, to be used as ``hooks/pre_gen_project.py``:
         sys.exit(1)
 
 .. _user-config:
-	
+
 User Config (0.7.0+)
 ----------------------
 
@@ -209,11 +209,11 @@ Here is a `cookiecuttter.json` with templated values for this pattern::
 
     {
       "project_name": "My New Project",
-      "repo_name": "{{ cookiecutter.project_name|lower|replace(' ', '-') }}",
-      "pkg_name": "{{ cookiecutter.repo_name|replace('-', '') }}"
+      "project_slug": "{{ cookiecutter.project_name|lower|replace(' ', '-') }}",
+      "pkg_name": "{{ cookiecutter.project_slug|replace('-', '') }}"
     }
 
-If the user takes the defaults, or uses `no_input`, the templated values will 
+If the user takes the defaults, or uses `no_input`, the templated values will
 be:
 
 * `my-new-project`
@@ -232,7 +232,7 @@ Copy without Render
 To avoid rendering directories and files of a cookiecutter mould, the `_copy_without_render` key can be used in the `cookiecutter.json`. The value of this key accepts a list of Unix shell-style wildcards::
 
     {
-        "repo_name": "sample",
+        "project_slug": "sample",
         "_copy_without_render": [
             "*.html",
             "*not_rendered_dir",
@@ -261,7 +261,7 @@ Example for a replay file (which was created via ``cookiecutter gh:hackebrot/coo
             "full_name": "Raphael Pierzina",
             "github_username": "hackebrot",
             "kivy_version": "1.8.0",
-            "repo_name": "foobar",
+            "project_slug": "foobar",
             "short_description": "A sleek slideshow app that supports swipe gestures.",
             "version": "0.1.0",
             "year": "2015"
@@ -291,7 +291,7 @@ Command Line Options
 .. cc-command-line-options::
 
 .. _choice-variables:
-   
+
 Choice Variables (1.1+)
 -----------------------
 
@@ -316,16 +316,16 @@ you'd get the following choices when running Cookiecutter::
    2 - BSD-3
    3 - GNU GPL v3.0
    4 - Apache Software License 2.0
-   Choose from 1, 2, 3, 4 [1]:		
+   Choose from 1, 2, 3, 4 [1]:
 
-Depending on an user's choice, a different license is rendered by Cookiecutter. 
+Depending on an user's choice, a different license is rendered by Cookiecutter.
 
 The above ``license`` choice variable creates ``cookiecutter.license``, which
 can be used like this::
 
   {%- if cookiecutter.license == "MIT" -%}
   # Possible license content here
-  
+
   {%- elif cookiecutter.license == "BSD-3" -%}
   # More possible license content here
 
@@ -337,7 +337,7 @@ The created choice variable is still a regular Cookiecutter variable and can be 
   -------
 
   Distributed under the terms of the `{{cookiecutter.license}}`_ license,
-  
+
 Overwriting Default Choice Values
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -355,11 +355,11 @@ Setting the default ``license`` agreement to *Apache Software License 2.0* can b
 
 .. code-block:: yaml
 
-   default_context:       
-       license: "Apache Software License 2.0"  
+   default_context:
+       license: "Apache Software License 2.0"
 
-in the :ref:`user-config` file. 
-       
+in the :ref:`user-config` file.
+
 The resulting prompt changes and looks like::
 
   Select license:

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -8,7 +8,7 @@ Input
 This is the directory structure for a simple cookiecutter::
 
     cookiecutter-something/
-    ├── {{ cookiecutter.repo_name }}/  <--------- Project template
+    ├── {{ cookiecutter.project_name }}/  <--------- Project template
     │   └── ...
     ├── blah.txt                      <--------- Non-templated files/dirs
     │                                            go outside
@@ -17,14 +17,11 @@ This is the directory structure for a simple cookiecutter::
 
 You must have:
 
-* A `{{ cookiecutter.repo_name }}/` directory.
 * A `cookiecutter.json` file.
+* A `{{ cookiecutter.project_name }}/` directory, where
+  `project_name` is defined in your `cookiecutter.json`.
 
 Beyond that, you can have whatever files/directories you want.
-
-.. note:: As of Cookiecutter 0.7.0, the top-level directory of your
-   cookiecutter must be called `{{ cookiecutter.repo_name }}`. However, in the
-   future, this will change.
 
 See https://github.com/audreyr/cookiecutter-pypackage for a real-world example
 of this.
@@ -35,8 +32,7 @@ Output
 This is what will be generated locally, in your current directory::
 
     mysomething/  <---------- Value corresponding to what you enter at the
-    │                         repo_name prompt
+    │                         project_name prompt
     │
     └── ...       <-------- Files corresponding to those in your
-                            cookiecutter's `{{ cookiecutter.repo_name }}/` dir
-
+                            cookiecutter's `{{ cookiecutter.project_name }}/` dir

--- a/docs/tutorial1.rst
+++ b/docs/tutorial1.rst
@@ -58,7 +58,7 @@ In your current directory, you should see that a project got generated:
     $ ls
     boilerplate
 
-Looking inside the `boilerplate/` (or directory corresponding to your `repo_name`)
+Looking inside the `boilerplate/` (or directory corresponding to your `project_slug`)
 directory, you should see something like this:
 
 .. code-block:: bash
@@ -101,18 +101,18 @@ Step 3: Observe How It Was Generated
 
 Let's take a look at cookiecutter-pypackage together. Open https://github.com/audreyr/cookiecutter-pypackage in a new browser window.
 
-{{ cookiecutter.repo_name }}
+{{ cookiecutter.project_slug }}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Find the directory called `{{ cookiecutter.repo_name }}`. Click on it. Observe
+Find the directory called `{{ cookiecutter.project_slug }}`. Click on it. Observe
 the files inside of it. You should see that this directory and its contents
 corresponds to the project that you just generated.
 
 AUTHORS.rst
 ~~~~~~~~~~~
 
-Look at the raw version of `{{ cookiecutter.repo_name }}/AUTHORS.rst`, at
-https://raw.github.com/audreyr/cookiecutter-pypackage/master/%7B%7Bcookiecutter.repo_name%7D%7D/AUTHORS.rst.
+Look at the raw version of `{{ cookiecutter.project_slug }}/AUTHORS.rst`, at
+https://raw.github.com/audreyr/cookiecutter-pypackage/master/%7B%7Bcookiecutter.project_slug%7D%7D/AUTHORS.rst.
 
 Observe how it corresponds to the `AUTHORS.rst` file that you generated.
 
@@ -128,15 +128,18 @@ earlier during project generation:
 .. code-block:: json
 
     {
-        "full_name": "Audrey Roy",
-        "email": "audreyr@gmail.com",
+        "full_name": "Audrey Roy Greenfeld",
+        "email": "aroy@alum.mit.edu",
         "github_username": "audreyr",
         "project_name": "Python Boilerplate",
-        "repo_name": "boilerplate",
+        "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_') }}",
         "project_short_description": "Python Boilerplate contains all the boilerplate you need to create a Python package.",
-        "release_date": "2013-08-11",
-        "year": "2013",
-        "version": "0.1.0"
+        "pypi_username": "{{ cookiecutter.github_username }}",
+        "version": "0.1.0",
+        "use_pytest": "n",
+        "use_pypi_deployment_with_travis": "y",
+        "create_author_file": "y",
+        "open_source_license": ["MIT", "BSD", "ISCL", "Apache Software License 2.0", "Not open source"]
     }
 
 Questions?

--- a/docs/tutorial2.rst
+++ b/docs/tutorial2.rst
@@ -15,10 +15,10 @@ Create the directory for your cookiecutter and cd into it:
     $ mkdir cookiecutter-website-simple
     $ cd cookiecutter-website-simple/
 
-Step 2: Create `repo_name` Directory
+Step 2: Create `project_slug` Directory
 -------------------------------------
 
-Create a directory called `{{ cookiecutter.repo_name }}`.
+Create a directory called `{{ cookiecutter.project_slug }}`.
 
 This value will be replaced with the repo name of projects that you generate
 from this cookiecutter.
@@ -26,7 +26,7 @@ from this cookiecutter.
 Step 3: Create Files
 --------------------
 
-Inside of `{{ cookiecutter.repo_name }}`, create `index.html`, `site.css`, and
+Inside of `{{ cookiecutter.project_slug }}`, create `index.html`, `site.css`, and
 `site.js`.
 
 To be continued...


### PR DESCRIPTION
Since naming the project template directory 'repo_name' is no longer required, I changed occurrences of it to 'project_slug' (matching the current `cookiecutter-pypackage`) and clarified that this is a templated value. I also updated the `cookiecutter-pypackage/cookiecutter.json` in the tutorial to match the current version.