### PR TITLE
Include template directory or url in the context dictionary

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -79,6 +79,9 @@ def cookiecutter(
         # except when 'no-input' flag is set
         context['cookiecutter'] = prompt_for_config(context, no_input)
 
+        # include template dir or url in the context dict
+        context['cookiecutter']['_template'] = template
+
         dump(config_dict['replay_dir'], template_name, context)
 
     # Create project from local context and project template.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -325,7 +325,8 @@ def test_echo_undefined_variable_error(tmpdir, cli_runner):
     context = {
         'cookiecutter': {
             'github_username': 'hackebrot',
-            'project_slug': 'testproject'
+            'project_slug': 'testproject',
+            '_template': template_path
         }
     }
     context_str = json.dumps(context, indent=4, sort_keys=True)


### PR DESCRIPTION
This is one use case: Have a make target in the rendered project that
pulls changes from the template source, renders the up-to-date template
with the same context used to create the project, and then merges the
changes back into the rendered project.
