### PR TITLE
Add support for executing cookiecutter using -m or from a checkout/zip file

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,6 @@
+"""Allow cookiecutter to be executable from a checkout or zip file."""
+import runpy
+
+
+if __name__ == "__main__":
+    runpy.run_module("cookiecutter", run_name="__main__")

--- a/cookiecutter/__main__.py
+++ b/cookiecutter/__main__.py
@@ -1,0 +1,8 @@
+"""Allow cookiecutter to be executable through `python -m cookiecutter`."""
+from __future__ import absolute_import
+
+from .cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/cookiecutter/__main__.py
+++ b/cookiecutter/__main__.py
@@ -4,5 +4,5 @@ from __future__ import absolute_import
 from .cli import main
 
 
-if __name__ == "__main__":
-    main()
+if __name__ == "__main__":  # pragma: no cover
+    main(prog_name="cookiecutter")

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     package_dir={'cookiecutter': 'cookiecutter'},
     entry_points={
         'console_scripts': [
-            'cookiecutter = cookiecutter.cli:main',
+            'cookiecutter = cookiecutter.__main__:main',
         ]
     },
     include_package_data=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ import pytest
 
 from click.testing import CliRunner
 
-from cookiecutter.cli import main
+from cookiecutter.__main__ import main
 from cookiecutter.main import cookiecutter
 from cookiecutter import utils, config
 


### PR DESCRIPTION
With this change you gain at least three ways to execute cookiecutter:

1. `python -m cookiecutter`
2. From a checkout: `python .`
3. From a zip file (that includes all necessary dependencies): `python cookiecutter.zip`

Closes #787