### PR TITLE
Fix files removed via make clean

### DIFF
--- a/tests/hooks-backup-files/hooks/post_gen_project.py~
+++ b/tests/hooks-backup-files/hooks/post_gen_project.py~
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-import logging
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger('post_gen_project')
-logger.info('post_gen_project.py~')

--- a/tests/hooks-backup-files/hooks/pre_gen_project.py~
+++ b/tests/hooks-backup-files/hooks/pre_gen_project.py~
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-import logging
-
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger('pre_gen_project')
-logger.info('pre_gen_project.py~')

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -211,7 +211,8 @@ def hook_backup_dir(tmpdir):
 
     yield str(hooks_dir)
 
-    hooks_dir.remove()
+    pre_gen_hook_file.remove()
+    post_gen_hook_file.remove()
 
 
 def test_ignore_hook_backup_files(monkeypatch, hook_backup_dir):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -189,7 +189,7 @@ def hook_backup_dir(tmpdir):
     hooks_dir = tmpdir.mkdir('hook-files')
 
     pre_hook_content = textwrap.dedent(
-        """
+        u"""
         #!/usr/bin/env python
         # -*- coding: utf-8 -*-
         print('pre_gen_project.py~')
@@ -199,7 +199,7 @@ def hook_backup_dir(tmpdir):
     pre_gen_hook_file.write_text(pre_hook_content, encoding='utf8')
 
     post_hook_content = textwrap.dedent(
-        """
+        u"""
         #!/usr/bin/env python
         # -*- coding: utf-8 -*-
         print('post_gen_project.py~')

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -183,10 +183,10 @@ class TestExternalHooks(object):
 
 
 @pytest.yield_fixture
-def hook_backup_dir(tmpdir):
+def dir_with_hooks(tmpdir):
     """Yield a directory that contains hook backup files."""
 
-    hooks_dir = tmpdir.mkdir('hook-files')
+    hooks_dir = tmpdir.mkdir('hooks')
 
     pre_hook_content = textwrap.dedent(
         u"""
@@ -209,12 +209,15 @@ def hook_backup_dir(tmpdir):
     post_gen_hook_file = hooks_dir / 'post_gen_project.py~'
     post_gen_hook_file.write_text(post_hook_content, encoding='utf8')
 
-    yield str(hooks_dir)
+    # Make sure to yield the parent directory as `find_hooks()`
+    # looks into `hooks/` in the current working directory
+    yield str(tmpdir)
 
     pre_gen_hook_file.remove()
     post_gen_hook_file.remove()
 
 
-def test_ignore_hook_backup_files(monkeypatch, hook_backup_dir):
-    monkeypatch.chdir(hook_backup_dir)
+def test_ignore_hook_backup_files(monkeypatch, dir_with_hooks):
+    # Change the current working directory that contains `hooks/`
+    monkeypatch.chdir(dir_with_hooks)
     assert hooks.find_hooks() == {}


### PR DESCRIPTION
We've added a couple of **hook backup files** as static files to our tests to make sure that they are not accidentally picked up as hooks in templates, see #768.

```
tests/hooks-backup-files/hooks/post_gen_project.py~
tests/hooks-backup-files/hooks/pre_gen_project.py~
```

The problem is that ``make clean`` removes such files and I have to ``git reset --hard`` to restore them as of now. 😢 

This PR creates the hook files in a **pytest.yield_fixture** and runs the test against them.