### PR TITLE
Implement cli_runner fixture for test_cli.py

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,15 +2,25 @@
 
 import os
 import json
-import pytest
 
 from click.testing import CliRunner
+import pytest
 
 from cookiecutter.__main__ import main
 from cookiecutter.main import cookiecutter
 from cookiecutter import utils, config
 
-runner = CliRunner()
+
+@pytest.fixture(scope='session')
+def cli_runner():
+    """Fixture that returns a helper function to run the cookiecutter cli."""
+    runner = CliRunner()
+
+    def cli_main(*cli_args):
+        """Run cookiecutter cli main with the given args."""
+        return runner.invoke(main, cli_args)
+
+    return cli_main
 
 
 @pytest.fixture
@@ -35,23 +45,23 @@ def version_cli_flag(request):
     return request.param
 
 
-def test_cli_version(version_cli_flag):
-    result = runner.invoke(main, [version_cli_flag])
+def test_cli_version(cli_runner, version_cli_flag):
+    result = cli_runner(version_cli_flag)
     assert result.exit_code == 0
     assert result.output.startswith('Cookiecutter')
 
 
 @pytest.mark.usefixtures('make_fake_project_dir', 'remove_fake_project_dir')
-def test_cli_error_on_existing_output_directory():
-    result = runner.invoke(main, ['tests/fake-repo-pre/', '--no-input'])
+def test_cli_error_on_existing_output_directory(cli_runner):
+    result = cli_runner('tests/fake-repo-pre/', '--no-input')
     assert result.exit_code != 0
     expected_error_msg = 'Error: "fake-project" directory already exists\n'
     assert result.output == expected_error_msg
 
 
 @pytest.mark.usefixtures('remove_fake_project_dir')
-def test_cli():
-    result = runner.invoke(main, ['tests/fake-repo-pre/', '--no-input'])
+def test_cli(cli_runner):
+    result = cli_runner('tests/fake-repo-pre/', '--no-input')
     assert result.exit_code == 0
     assert os.path.isdir('fake-project')
     with open(os.path.join('fake-project', 'README.rst')) as f:
@@ -59,8 +69,8 @@ def test_cli():
 
 
 @pytest.mark.usefixtures('remove_fake_project_dir')
-def test_cli_verbose():
-    result = runner.invoke(main, ['tests/fake-repo-pre/', '--no-input', '-v'])
+def test_cli_verbose(cli_runner):
+    result = cli_runner('tests/fake-repo-pre/', '--no-input', '-v')
     assert result.exit_code == 0
     assert os.path.isdir('fake-project')
     with open(os.path.join('fake-project', 'README.rst')) as f:
@@ -68,17 +78,13 @@ def test_cli_verbose():
 
 
 @pytest.mark.usefixtures('remove_fake_project_dir')
-def test_cli_replay(mocker):
+def test_cli_replay(mocker, cli_runner):
     mock_cookiecutter = mocker.patch(
         'cookiecutter.cli.cookiecutter'
     )
 
     template_path = 'tests/fake-repo-pre/'
-    result = runner.invoke(main, [
-        template_path,
-        '--replay',
-        '-v'
-    ])
+    result = cli_runner(template_path, '--replay', '-v')
 
     assert result.exit_code == 0
     mock_cookiecutter.assert_called_once_with(
@@ -94,19 +100,14 @@ def test_cli_replay(mocker):
 
 
 @pytest.mark.usefixtures('remove_fake_project_dir')
-def test_cli_exit_on_noinput_and_replay(mocker):
+def test_cli_exit_on_noinput_and_replay(mocker, cli_runner):
     mock_cookiecutter = mocker.patch(
         'cookiecutter.cli.cookiecutter',
         side_effect=cookiecutter
     )
 
     template_path = 'tests/fake-repo-pre/'
-    result = runner.invoke(main, [
-        template_path,
-        '--no-input',
-        '--replay',
-        '-v'
-    ])
+    result = cli_runner(template_path, '--no-input', '--replay', '-v')
 
     assert result.exit_code == 1
 
@@ -136,19 +137,14 @@ def overwrite_cli_flag(request):
 
 @pytest.mark.usefixtures('remove_fake_project_dir')
 def test_run_cookiecutter_on_overwrite_if_exists_and_replay(
-        mocker, overwrite_cli_flag):
+        mocker, cli_runner, overwrite_cli_flag):
     mock_cookiecutter = mocker.patch(
         'cookiecutter.cli.cookiecutter',
         side_effect=cookiecutter
     )
 
     template_path = 'tests/fake-repo-pre/'
-    result = runner.invoke(main, [
-        template_path,
-        '--replay',
-        '-v',
-        overwrite_cli_flag,
-    ])
+    result = cli_runner(template_path, '--replay', '-v', overwrite_cli_flag)
 
     assert result.exit_code == 0
 
@@ -166,20 +162,27 @@ def test_run_cookiecutter_on_overwrite_if_exists_and_replay(
 
 @pytest.mark.usefixtures('remove_fake_project_dir')
 def test_cli_overwrite_if_exists_when_output_dir_does_not_exist(
-        overwrite_cli_flag):
-    result = runner.invoke(main, [
-        'tests/fake-repo-pre/', '--no-input', overwrite_cli_flag
-    ])
+        cli_runner, overwrite_cli_flag):
+
+    result = cli_runner(
+        'tests/fake-repo-pre/',
+        '--no-input',
+        overwrite_cli_flag,
+    )
 
     assert result.exit_code == 0
     assert os.path.isdir('fake-project')
 
 
 @pytest.mark.usefixtures('make_fake_project_dir', 'remove_fake_project_dir')
-def test_cli_overwrite_if_exists_when_output_dir_exists(overwrite_cli_flag):
-    result = runner.invoke(main, [
-        'tests/fake-repo-pre/', '--no-input', overwrite_cli_flag
-    ])
+def test_cli_overwrite_if_exists_when_output_dir_exists(
+        cli_runner, overwrite_cli_flag):
+
+    result = cli_runner(
+        'tests/fake-repo-pre/',
+        '--no-input',
+        overwrite_cli_flag,
+    )
     assert result.exit_code == 0
     assert os.path.isdir('fake-project')
 
@@ -194,17 +197,13 @@ def output_dir(tmpdir):
     return str(tmpdir.mkdir('output'))
 
 
-def test_cli_output_dir(mocker, output_dir_flag, output_dir):
+def test_cli_output_dir(mocker, cli_runner, output_dir_flag, output_dir):
     mock_cookiecutter = mocker.patch(
         'cookiecutter.cli.cookiecutter'
     )
 
     template_path = 'tests/fake-repo-pre/'
-    result = runner.invoke(main, [
-        template_path,
-        output_dir_flag,
-        output_dir
-    ])
+    result = cli_runner(template_path, output_dir_flag, output_dir)
 
     assert result.exit_code == 0
     mock_cookiecutter.assert_called_once_with(
@@ -224,8 +223,8 @@ def help_cli_flag(request):
     return request.param
 
 
-def test_cli_help(help_cli_flag):
-    result = runner.invoke(main, [help_cli_flag])
+def test_cli_help(cli_runner, help_cli_flag):
+    result = cli_runner(help_cli_flag)
     assert result.exit_code == 0
     assert result.output.startswith('Usage')
 
@@ -235,17 +234,13 @@ def user_config_path(tmpdir):
     return str(tmpdir.join('tests/config.yaml'))
 
 
-def test_user_config(mocker, user_config_path):
+def test_user_config(mocker, cli_runner, user_config_path):
     mock_cookiecutter = mocker.patch(
         'cookiecutter.cli.cookiecutter'
     )
 
     template_path = 'tests/fake-repo-pre/'
-    result = runner.invoke(main, [
-        template_path,
-        '--config-file',
-        user_config_path
-    ])
+    result = cli_runner(template_path, '--config-file', user_config_path)
 
     assert result.exit_code == 0
     mock_cookiecutter.assert_called_once_with(
@@ -260,18 +255,18 @@ def test_user_config(mocker, user_config_path):
     )
 
 
-def test_default_user_config_overwrite(mocker, user_config_path):
+def test_default_user_config_overwrite(mocker, cli_runner, user_config_path):
     mock_cookiecutter = mocker.patch(
         'cookiecutter.cli.cookiecutter'
     )
 
     template_path = 'tests/fake-repo-pre/'
-    result = runner.invoke(main, [
+    result = cli_runner(
         template_path,
         '--config-file',
         user_config_path,
-        '--default-config'
-    ])
+        '--default-config',
+    )
 
     assert result.exit_code == 0
     mock_cookiecutter.assert_called_once_with(
@@ -286,16 +281,13 @@ def test_default_user_config_overwrite(mocker, user_config_path):
     )
 
 
-def test_default_user_config(mocker):
+def test_default_user_config(mocker, cli_runner):
     mock_cookiecutter = mocker.patch(
         'cookiecutter.cli.cookiecutter'
     )
 
     template_path = 'tests/fake-repo-pre/'
-    result = runner.invoke(main, [
-        template_path,
-        '--default-config'
-    ])
+    result = cli_runner(template_path, '--default-config')
 
     assert result.exit_code == 0
     mock_cookiecutter.assert_called_once_with(
@@ -310,17 +302,17 @@ def test_default_user_config(mocker):
     )
 
 
-def test_echo_undefined_variable_error(tmpdir):
+def test_echo_undefined_variable_error(tmpdir, cli_runner):
     output_dir = str(tmpdir.mkdir('output'))
     template_path = 'tests/undefined-variable/file-name/'
 
-    result = runner.invoke(main, [
+    result = cli_runner(
         '--no-input',
         '--default-config',
         '--output-dir',
         output_dir,
         template_path,
-    ])
+    )
 
     assert result.exit_code == 1
 
@@ -340,17 +332,17 @@ def test_echo_undefined_variable_error(tmpdir):
     assert context_str in result.output
 
 
-def test_echo_unknown_extension_error(tmpdir):
+def test_echo_unknown_extension_error(tmpdir, cli_runner):
     output_dir = str(tmpdir.mkdir('output'))
     template_path = 'tests/test-extensions/unknown/'
 
-    result = runner.invoke(main, [
+    result = cli_runner(
         '--no-input',
         '--default-config',
         '--output-dir',
         output_dir,
         template_path,
-    ])
+    )
 
     assert result.exit_code == 1
 
@@ -358,9 +350,13 @@ def test_echo_unknown_extension_error(tmpdir):
 
 
 @pytest.mark.usefixtures('remove_fake_project_dir')
-def test_cli_extra_context():
-    result = runner.invoke(main, ['tests/fake-repo-pre/', '--no-input', '-v',
-                                  'project_name=Awesomez'])
+def test_cli_extra_context(cli_runner):
+    result = cli_runner(
+        'tests/fake-repo-pre/',
+        '--no-input',
+        '-v',
+        'project_name=Awesomez',
+    )
     assert result.exit_code == 0
     assert os.path.isdir('fake-project')
     with open(os.path.join('fake-project', 'README.rst')) as f:
@@ -368,9 +364,13 @@ def test_cli_extra_context():
 
 
 @pytest.mark.usefixtures('remove_fake_project_dir')
-def test_cli_extra_context_invalid_format():
-    result = runner.invoke(main, ['tests/fake-repo-pre/', '--no-input', '-v',
-                                  'ExtraContextWithNoEqualsSoInvalid'])
+def test_cli_extra_context_invalid_format(cli_runner):
+    result = cli_runner(
+        'tests/fake-repo-pre/',
+        '--no-input',
+        '-v',
+        'ExtraContextWithNoEqualsSoInvalid',
+    )
     assert result.exit_code == 2
     assert 'Error: Invalid value for "extra_context"' in result.output
     assert 'should contain items of the form key=value' in result.output


### PR DESCRIPTION
This makes it even easier to write CLI tests. 😂 

Currently:

```python
result = runner.invoke(main, ['--verbose', template])
```

With this PR:

```python
result = cli_runner('--verbose', template)
```