### PR TITLE
add a jsonify filter to jinja default extensions

### DIFF
--- a/cookiecutter/environment.py
+++ b/cookiecutter/environment.py
@@ -25,6 +25,7 @@ class ExtensionLoaderMixin(object):
 
         default_extensions = [
             'jinja2_time.TimeExtension',
+            'cookiecutter.extensions.JsonifyExtension'
         ]
         extensions = default_extensions + self._read_extensions(context)
 

--- a/cookiecutter/extensions.py
+++ b/cookiecutter/extensions.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""Jinja2 extensions."""
+
+from jinja2.ext import Extension
+import json
+
+
+class JsonifyExtension(Extension):
+    """Jinja2 extension to convert a python object to json"""
+    def __init__(self, environment):
+        super(JsonifyExtension, self).__init__(environment)
+
+        def jsonify(obj):
+            return json.dumps(obj, sort_keys=True, indent=4)
+
+        environment.filters['jsonify'] = jsonify

--- a/tests/files/{{cookiecutter.jsonify_file}}.txt
+++ b/tests/files/{{cookiecutter.jsonify_file}}.txt
@@ -1,0 +1,1 @@
+{{ cookiecutter | jsonify }}

--- a/tests/test_generate_file.py
+++ b/tests/test_generate_file.py
@@ -12,6 +12,7 @@ TestGenerateFile.test_generate_file_verbose_template_syntax_error
 from __future__ import unicode_literals
 import os
 import pytest
+import json
 
 from jinja2 import FileSystemLoader
 from jinja2.exceptions import TemplateSyntaxError
@@ -63,6 +64,22 @@ def test_generate_file_with_false_condition(env):
         env=env
     )
     assert not os.path.exists('tests/files/cheese.txt')
+
+
+@pytest.mark.usefixtures('remove_cheese_file')
+def test_generate_file_jsonify_filter(env):
+    infile = 'tests/files/{{cookiecutter.jsonify_file}}.txt'
+    data = {'jsonify_file': 'cheese', 'type': 'roquefort'}
+    generate.generate_file(
+        project_dir=".",
+        infile=infile,
+        context={'cookiecutter': data},
+        env=env
+    )
+    assert os.path.isfile('tests/files/cheese.txt')
+    with open('tests/files/cheese.txt', 'rt') as f:
+        generated_text = f.read()
+        assert json.loads(generated_text) == data
 
 
 @pytest.mark.usefixtures('remove_cheese_file')


### PR DESCRIPTION
This enables a template like this

```
{{ cookiecutter | jsonify }}
```

that renders the a python object as json, as suggested in #784
