### PR TITLE
Make the build reproducible by avoiding nondeterministic kwargs

### DIFF
--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -21,6 +21,7 @@ from .exceptions import InvalidConfiguration
 
 logger = logging.getLogger(__name__)
 
+NOT_PROVIDED = object()
 USER_CONFIG_PATH = os.path.expanduser('~/.cookiecutterrc')
 
 BUILTIN_ABBREVIATIONS = {
@@ -73,7 +74,7 @@ def get_config(config_path):
     return config_dict
 
 
-def get_user_config(config_file=USER_CONFIG_PATH):
+def get_user_config(config_file=NOT_PROVIDED):
     """Retrieve the config from a file or return the defaults if None is
     passed. If an environment variable `COOKIECUTTER_CONFIG` is set up, try
     to load its value. Otherwise fall back to a default file or config.
@@ -81,6 +82,10 @@ def get_user_config(config_file=USER_CONFIG_PATH):
     # Do NOT load a config. Return defaults instead.
     if config_file is None:
         return copy.copy(DEFAULT_CONFIG)
+
+    # Differentiate between being passed ``None`` and the default.
+    if config_file is NOT_PROVIDED:
+        config_file = USER_CONFIG_PATH
 
     # Load the given config file
     if config_file and config_file is not USER_CONFIG_PATH:

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -14,7 +14,7 @@ from __future__ import unicode_literals
 import logging
 import os
 
-from .config import get_user_config, USER_CONFIG_PATH
+from .config import get_user_config, NOT_PROVIDED
 from .generate import generate_context, generate_files
 from .exceptions import InvalidModeException
 from .prompt import prompt_for_config
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 def cookiecutter(
         template, checkout=None, no_input=False, extra_context=None,
         replay=False, overwrite_if_exists=False, output_dir='.',
-        config_file=USER_CONFIG_PATH):
+        config_file=NOT_PROVIDED):
     """
     API equivalent to using Cookiecutter at the command line.
 


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], I noticed
that cookiecutter could not be built reproducibly.

As USER_CONFIG_PATH is pased on expanding ~ this varies between different
systems, meaning that building the documentation on a different machine (or
with a different $HOME) ends up with a different result:
- [..] config_file=u'/nonexistent/first-build/.cookiecutterrc' [..]
- [..] config_file=u'/nonexistent/second-build/.cookiecutterrc' [..]

I would normally just change this to `config_file=None` and set it at
runtime, but we need to be clever with NOT_PROVIDED to tell the difference
between the case where we _actually_ pass ``None`..

 [0] https://reproducible-builds.org/

Signed-off-by: Chris Lamb chris@chris-lamb.co.uk
