### PR TITLE
Use existing cookiecutters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Did someone say features?
         # For the sake of brevity, repos on GitHub can just use the 'gh' prefix
         $ cookiecutter gh:audreyr/cookiecutter-pypackage
 
-* Can also use it at the command line with a local template:
+* Use it at the command line with a local template:
 
     .. code-block:: bash
 
@@ -128,6 +128,16 @@ Did someone say features?
 
 * Cookiecutters (cloned Cookiecutter project templates) are put into
   `~/.cookiecutters/` by default, or cookiecutters_dir if specified.
+
+* If you have already cloned a cookiecutter into `~/.cookiecutters/`, you
+  can reference it by directory name:
+
+    .. code-block:: bash
+
+        # Clone cookiecutter-pypackage
+        $ cookiecutter gh:audreyr/cookiecutter-pypackage
+        # Now you can use the already cloned cookiecutter by name
+        $ cookiecutter cookiecutter-pypackage
 
 * You can use local cookiecutters, or remote cookiecutters directly from Git
   repos or from Mercurial repos on Bitbucket.

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Did someone say features?
 
 * 100% of templating is done with Jinja2. This includes file and directory names.
 
-* Simply define your template variables in a `cookiecutter.json` file. For example:
+* Simply define your template variables in a ``cookiecutter.json`` file. For example:
 
     .. code-block:: json
 
@@ -110,13 +110,13 @@ Did someone say features?
             "version": "0.1.1"
         }
 
-* Unless you suppress it with `--no-input`, you are prompted for input:
+* Unless you suppress it with ``--no-input``, you are prompted for input:
 
-  - Prompts are the keys in `cookiecutter.json`.
-  - Default responses are the values in `cookiecutter.json`.
+  - Prompts are the keys in ``cookiecutter.json``.
+  - Default responses are the values in ``cookiecutter.json``.
   - Prompts are shown in order.
 
-* Cross-platform support for `~/.cookiecutterrc` files:
+* Cross-platform support for ``~/.cookiecutterrc`` files:
 
     .. code-block:: yaml
 
@@ -127,9 +127,9 @@ Did someone say features?
         cookiecutters_dir: "~/.cookiecutters/"
 
 * Cookiecutters (cloned Cookiecutter project templates) are put into
-  `~/.cookiecutters/` by default, or cookiecutters_dir if specified.
+  ``~/.cookiecutters/`` by default, or cookiecutters_dir if specified.
 
-* If you have already cloned a cookiecutter into `~/.cookiecutters/`, you
+* If you have already cloned a cookiecutter into ``~/.cookiecutters/``, you
   can reference it by directory name:
 
     .. code-block:: bash

--- a/cookiecutter/repository.py
+++ b/cookiecutter/repository.py
@@ -76,25 +76,27 @@ def determine_repo_dir(template, abbreviations, clone_to_dir, checkout,
     """
     template = expand_abbreviations(template, abbreviations)
 
+    repository_candidates = []
+
     if is_repo_url(template):
-        return clone(
+        cloned_repo = clone(
             repo_url=template,
             checkout=checkout,
             clone_to_dir=clone_to_dir,
             no_input=no_input,
         )
-    else:
-        # If it's a local repo, no need to clone or copy to your
-        # cookiecutters_dir
-        repo_dir = template
-        if not repository_has_cookiecutter_json(repo_dir):
-            already_cloned_cookiecutter = os.path.join(clone_to_dir, template)
-            repo_dir = already_cloned_cookiecutter
+        repository_candidates.append(cloned_repo)
 
-    if repository_has_cookiecutter_json(repo_dir):
-        return repo_dir
+    repository_candidates.extend([
+        template,
+        os.path.join(clone_to_dir, template)
+    ])
+
+    for repo_candidate in repository_candidates:
+        if repository_has_cookiecutter_json(repo_candidate):
+            return repo_candidate
 
     raise RepositoryNotFound(
         'The repository {} could not be located or does not contain '
-        'a "cookiecutter.json" file.'.format(repo_dir)
+        'a "cookiecutter.json" file.'.format(template)
     )

--- a/cookiecutter/repository.py
+++ b/cookiecutter/repository.py
@@ -95,6 +95,9 @@ def determine_repo_dir(template, abbreviations, clone_to_dir, checkout,
             return repo_candidate
 
     raise RepositoryNotFound(
-        'The repository {} could not be located or does not contain '
-        'a "cookiecutter.json" file.'.format(template)
+        'A valid repository for "{}" could not be found in the following '
+        'locations:\n{}'.format(
+            template,
+            '\n'.join(repository_candidates)
+        )
     )

--- a/cookiecutter/repository.py
+++ b/cookiecutter/repository.py
@@ -87,6 +87,9 @@ def determine_repo_dir(template, abbreviations, clone_to_dir, checkout,
         # If it's a local repo, no need to clone or copy to your
         # cookiecutters_dir
         repo_dir = template
+        if not valid_repository(repo_dir):
+            already_cloned_cookiecutter = os.path.join(clone_to_dir, template)
+            repo_dir = already_cloned_cookiecutter
 
     if repository_has_cookiecutter_json(repo_dir):
         return repo_dir

--- a/cookiecutter/repository.py
+++ b/cookiecutter/repository.py
@@ -77,7 +77,7 @@ def determine_repo_dir(template, abbreviations, clone_to_dir, checkout,
     template = expand_abbreviations(template, abbreviations)
 
     if is_repo_url(template):
-        repo_dir = clone(
+        return clone(
             repo_url=template,
             checkout=checkout,
             clone_to_dir=clone_to_dir,
@@ -87,7 +87,7 @@ def determine_repo_dir(template, abbreviations, clone_to_dir, checkout,
         # If it's a local repo, no need to clone or copy to your
         # cookiecutters_dir
         repo_dir = template
-        if not valid_repository(repo_dir):
+        if not repository_has_cookiecutter_json(repo_dir):
             already_cloned_cookiecutter = os.path.join(clone_to_dir, template)
             repo_dir = already_cloned_cookiecutter
 

--- a/cookiecutter/repository.py
+++ b/cookiecutter/repository.py
@@ -76,8 +76,6 @@ def determine_repo_dir(template, abbreviations, clone_to_dir, checkout,
     """
     template = expand_abbreviations(template, abbreviations)
 
-    repository_candidates = []
-
     if is_repo_url(template):
         cloned_repo = clone(
             repo_url=template,
@@ -85,12 +83,12 @@ def determine_repo_dir(template, abbreviations, clone_to_dir, checkout,
             clone_to_dir=clone_to_dir,
             no_input=no_input,
         )
-        repository_candidates.append(cloned_repo)
-
-    repository_candidates.extend([
-        template,
-        os.path.join(clone_to_dir, template)
-    ])
+        repository_candidates = [cloned_repo]
+    else:
+        repository_candidates = [
+            template,
+            os.path.join(clone_to_dir, template)
+        ]
 
     for repo_candidate in repository_candidates:
         if repository_has_cookiecutter_json(repo_candidate):

--- a/tests/repository/test_determine_repo_dir_clones_repo.py
+++ b/tests/repository/test_determine_repo_dir_clones_repo.py
@@ -58,7 +58,7 @@ def test_repository_url_with_no_context_file(
         repository.determine_repo_dir(
             template_url,
             abbreviations={},
-            clone_to_dir=user_config_data['cookiecutters_dir'],
+            clone_to_dir=None,
             checkout=None,
             no_input=True
         )

--- a/tests/repository/test_determine_repo_dir_clones_repo.py
+++ b/tests/repository/test_determine_repo_dir_clones_repo.py
@@ -46,7 +46,8 @@ def test_repository_url_should_clone(
     assert 'tests/fake-repo-tmpl' == project_dir
 
 
-def test_repository_url_with_no_context_file(mocker, template_url):
+def test_repository_url_with_no_context_file(
+        mocker, template_url, user_config_data):
     mocker.patch(
         'cookiecutter.repository.clone',
         return_value='tests/fake-repo-bad',
@@ -57,7 +58,7 @@ def test_repository_url_with_no_context_file(mocker, template_url):
         repository.determine_repo_dir(
             template_url,
             abbreviations={},
-            clone_to_dir=None,
+            clone_to_dir=user_config_data['cookiecutters_dir'],
             checkout=None,
             no_input=True
         )

--- a/tests/repository/test_determine_repo_dir_clones_repo.py
+++ b/tests/repository/test_determine_repo_dir_clones_repo.py
@@ -64,6 +64,9 @@ def test_repository_url_with_no_context_file(
         )
 
     assert str(err.value) == (
-        'The repository {} could not be located or does not '
-        'contain a "cookiecutter.json" file.'.format(template_url)
+        'A valid repository for "{}" could not be found in the following '
+        'locations:\n{}'.format(
+            template_url,
+            'tests/fake-repo-bad',
+        )
     )

--- a/tests/repository/test_determine_repo_dir_clones_repo.py
+++ b/tests/repository/test_determine_repo_dir_clones_repo.py
@@ -64,6 +64,6 @@ def test_repository_url_with_no_context_file(
         )
 
     assert str(err.value) == (
-        'The repository tests/fake-repo-bad could not be located or does not '
-        'contain a "cookiecutter.json" file.'
+        'The repository {} could not be located or does not '
+        'contain a "cookiecutter.json" file.'.format(template_url)
     )

--- a/tests/repository/test_determine_repo_dir_finds_existing_cookiecutter.py
+++ b/tests/repository/test_determine_repo_dir_finds_existing_cookiecutter.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+import io
+import os
+
+from cookiecutter import repository
+
+
+def test_should_find_existing_cookiecutter(user_config_data):
+    template = 'cookiecutter-pytest-plugin'
+    cookiecutters_dir = user_config_data['cookiecutters_dir']
+    cloned_template_path = os.path.join(cookiecutters_dir, template)
+    os.mkdir(cloned_template_path)
+    io.open(os.path.join(cloned_template_path, 'cookiecutter.json'), 'w')
+
+    project_dir = repository.determine_repo_dir(
+        template,
+        abbreviations={},
+        clone_to_dir=cookiecutters_dir,
+        checkout=None,
+        no_input=True,
+    )
+
+    assert cloned_template_path == project_dir

--- a/tests/repository/test_determine_repo_dir_finds_existing_cookiecutter.py
+++ b/tests/repository/test_determine_repo_dir_finds_existing_cookiecutter.py
@@ -1,23 +1,36 @@
 # -*- coding: utf-8 -*-
 import io
 import os
+import pytest
 
 from cookiecutter import repository
 
 
-def test_should_find_existing_cookiecutter(user_config_data):
-    template = 'cookiecutter-pytest-plugin'
+@pytest.fixture
+def template():
+    return 'cookiecutter-pytest-plugin'
+
+
+@pytest.fixture
+def cloned_cookiecutter_path(user_config_data, template):
     cookiecutters_dir = user_config_data['cookiecutters_dir']
+
     cloned_template_path = os.path.join(cookiecutters_dir, template)
     os.mkdir(cloned_template_path)
+
     io.open(os.path.join(cloned_template_path, 'cookiecutter.json'), 'w')
 
+    return cloned_template_path
+
+
+def test_should_find_existing_cookiecutter(
+        template, user_config_data, cloned_cookiecutter_path):
     project_dir = repository.determine_repo_dir(
         template,
         abbreviations={},
-        clone_to_dir=cookiecutters_dir,
+        clone_to_dir=user_config_data['cookiecutters_dir'],
         checkout=None,
         no_input=True,
     )
 
-    assert cloned_template_path == project_dir
+    assert cloned_cookiecutter_path == project_dir

--- a/tests/repository/test_determine_repository_should_use_local_repo.py
+++ b/tests/repository/test_determine_repository_should_use_local_repo.py
@@ -4,12 +4,12 @@ from cookiecutter import repository, exceptions
 import pytest
 
 
-def test_finds_local_repo():
+def test_finds_local_repo(tmpdir):
     """A valid local repository should be returned."""
     project_dir = repository.determine_repo_dir(
         'tests/fake-repo',
         abbreviations={},
-        clone_to_dir=None,
+        clone_to_dir=str(tmpdir),
         checkout=None,
         no_input=True
     )
@@ -17,7 +17,7 @@ def test_finds_local_repo():
     assert 'tests/fake-repo' == project_dir
 
 
-def test_local_repo_with_no_context_raises():
+def test_local_repo_with_no_context_raises(tmpdir):
     """A local repository without a cookiecutter.json should raise a
     `RepositoryNotFound` exception.
     """
@@ -25,7 +25,7 @@ def test_local_repo_with_no_context_raises():
         repository.determine_repo_dir(
             'tests/fake-repo-bad',
             abbreviations={},
-            clone_to_dir=None,
+            clone_to_dir=str(tmpdir),
             checkout=None,
             no_input=True
         )
@@ -36,7 +36,7 @@ def test_local_repo_with_no_context_raises():
     )
 
 
-def test_local_repo_typo():
+def test_local_repo_typo(tmpdir):
     """An unknown local repository should raise a `RepositoryNotFound`
     exception.
     """
@@ -44,7 +44,7 @@ def test_local_repo_typo():
         repository.determine_repo_dir(
             'tests/unknown-repo',
             abbreviations={},
-            clone_to_dir=None,
+            clone_to_dir=str(tmpdir),
             checkout=None,
             no_input=True
         )

--- a/tests/repository/test_determine_repository_should_use_local_repo.py
+++ b/tests/repository/test_determine_repository_should_use_local_repo.py
@@ -31,8 +31,14 @@ def test_local_repo_with_no_context_raises(tmpdir):
         )
 
     assert str(err.value) == (
-        'The repository tests/fake-repo-bad could not be located or does not '
-        'contain a "cookiecutter.json" file.'
+        'A valid repository for "{}" could not be found in the following '
+        'locations:\n{}'.format(
+            'tests/fake-repo-bad',
+            '\n'.join([
+                'tests/fake-repo-bad',
+                str(tmpdir / 'tests/fake-repo-bad')
+            ]),
+        )
     )
 
 
@@ -50,6 +56,12 @@ def test_local_repo_typo(tmpdir):
         )
 
     assert str(err.value) == (
-        'The repository tests/unknown-repo could not be located or does not '
-        'contain a "cookiecutter.json" file.'
+        'A valid repository for "{}" could not be found in the following '
+        'locations:\n{}'.format(
+            'tests/unknown-repo',
+            '\n'.join([
+                'tests/unknown-repo',
+                str(tmpdir / 'tests/unknown-repo')
+            ]),
+        )
     )

--- a/tests/repository/test_determine_repository_should_use_local_repo.py
+++ b/tests/repository/test_determine_repository_should_use_local_repo.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 from cookiecutter import repository, exceptions
 
 import pytest
@@ -21,9 +22,10 @@ def test_local_repo_with_no_context_raises(tmpdir):
     """A local repository without a cookiecutter.json should raise a
     `RepositoryNotFound` exception.
     """
+    template_path = os.path.join('tests', 'fake-repo-bad')
     with pytest.raises(exceptions.RepositoryNotFound) as err:
         repository.determine_repo_dir(
-            'tests/fake-repo-bad',
+            template_path,
             abbreviations={},
             clone_to_dir=str(tmpdir),
             checkout=None,
@@ -33,9 +35,9 @@ def test_local_repo_with_no_context_raises(tmpdir):
     assert str(err.value) == (
         'A valid repository for "{}" could not be found in the following '
         'locations:\n{}'.format(
-            'tests/fake-repo-bad',
+            template_path,
             '\n'.join([
-                'tests/fake-repo-bad',
+                template_path,
                 str(tmpdir / 'tests/fake-repo-bad')
             ]),
         )
@@ -46,9 +48,10 @@ def test_local_repo_typo(tmpdir):
     """An unknown local repository should raise a `RepositoryNotFound`
     exception.
     """
+    template_path = os.path.join('tests', 'unknown-repo')
     with pytest.raises(exceptions.RepositoryNotFound) as err:
         repository.determine_repo_dir(
-            'tests/unknown-repo',
+            template_path,
             abbreviations={},
             clone_to_dir=str(tmpdir),
             checkout=None,
@@ -58,9 +61,9 @@ def test_local_repo_typo(tmpdir):
     assert str(err.value) == (
         'A valid repository for "{}" could not be found in the following '
         'locations:\n{}'.format(
-            'tests/unknown-repo',
+            template_path,
             '\n'.join([
-                'tests/unknown-repo',
+                template_path,
                 str(tmpdir / 'tests/unknown-repo')
             ]),
         )


### PR DESCRIPTION
Existing cookiecutters in `~/.cookiecutters` can now be referenced by directory name.

Fixes #385.