### PR TITLE
Added cc-automated-drf-template

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -396,6 +396,7 @@ Python-Django
 * `cc_django_ember_app`_: For creating applications with Django and EmberJS
 * `cc_project_app_drf`_: For creating REST apis based on the "project app" project architecture
 * `cc_project_app_full_with_hooks`_: For creating Django projects using the "project app" project architecture
+* `cc-automated-drf-template`_: A template + script that automatically creates your Django REST project with serializers, views, urls, and admin files based on your models file as input.
 
 .. _`cookiecutter-django`: https://github.com/pydanny/cookiecutter-django
 .. _`cookiecutter-django-rest`: https://github.com/agconti/cookiecutter-django-rest
@@ -419,6 +420,7 @@ Python-Django
 .. _`cc_django_ember_app`: https://bitbucket.org/levit_scs/cc_django_ember_app
 .. _`cc_project_app_drf`: https://bitbucket.org/levit_scs/cc_project_app_drf
 .. _`cc_project_app_full_with_hooks`: https://bitbucket.org/levit_scs/cc_project_app_full_with_hooks
+.. _`cc-automated-drf-template`: https://github.com/TAMU-CPT/cc-automated-drf-template
 
 
 Python-Pyramid


### PR DESCRIPTION
cc_automated_drf_template uses Cookiecutter and a custom script to automatically populate a Django REST project given a models.py. Just provide your models and cc_automated_drf_template will write your views, serializers, urls, and admin for you.