### PR TITLE
fix travis-ci python3.6 build and add python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,10 @@ matrix:
         env: TOX_ENV=py34
       - python: 3.5
         env: TOX_ENV=py35
-      - python: nightly
+      - python: 3.6-dev
         env: TOX_ENV=py36
+      - python: nightly
+        env: TOX_ENV=py37
       - python: pypy
         env: TOX_ENV=pypy
       - python: 3.5

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist = py27, py33, py34, py35, pypy, flake8
 
 [tox:travis]
-nightly = py36
+3.6-dev = py36
+nightly = py37
 
 [testenv]
 passenv = LC_ALL, LANG, HOME


### PR DESCRIPTION
* Fix python3.6 travis-ci and tox configuration
* Add python3.7 travis-ci and tox configuration

ps: the build will fail with `tox==2.4.1`, however, this error has been fixed (https://github.com/tox-dev/tox/pull/382) and will be shipped with the next `tox` version 