### PR TITLE
Consistently use encoding declarations

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Allow cookiecutter to be executable from a checkout or zip file."""
 import runpy
 

--- a/cookiecutter/__main__.py
+++ b/cookiecutter/__main__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Allow cookiecutter to be executable through `python -m cookiecutter`."""
 from __future__ import absolute_import
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import os
 import io

--- a/tests/replay/conftest.py
+++ b/tests/replay/conftest.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 


### PR DESCRIPTION
A minor change that adds ``# -*- coding: utf-8 -*-`` to python files that didn't have them before.

Fixes #814