### PR TITLE
Extend CLI help message

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -95,7 +95,12 @@ def main(
         template, extra_context, no_input, checkout, verbose,
         replay, overwrite_if_exists, output_dir, config_file,
         default_config, debug_file):
-    """Create a project from a Cookiecutter project template (TEMPLATE)."""
+    """Create a project from a Cookiecutter project template (TEMPLATE).
+
+    Cookiecutter is free and open source software, developed and managed by
+    volunteers. If you would like to help out or fund the project, please get
+    in touch at https://github.com/audreyr/cookiecutter.
+    """
 
     # If you _need_ to support a local template in a directory
     # called 'help', use a qualified path to the directory.


### PR DESCRIPTION
I'm not sure if this is something we want, but wanted to at least discuss it.

```text
$ cookiecutter --help
Usage: cookiecutter [OPTIONS] TEMPLATE [EXTRA_CONTEXT]...

  Create a project from a Cookiecutter project template (TEMPLATE).

  Cookiecutter is free and open source software, developed and managed by
  volunteers. If you would like to help out or fund the project, please get
  in touch at https://github.com/audreyr/cookiecutter.

Options:
  -V, --version              Show the version and exit.
  --no-input                 Do not prompt for parameters and only use
                             cookiecutter.json file content
  -c, --checkout TEXT        branch, tag or commit to checkout after git clone
  -v, --verbose              Print debug information
  --replay                   Do not prompt for parameters and only use
                             information entered previously
  -f, --overwrite-if-exists  Overwrite the contents of the output directory if
                             it already exists
  -o, --output-dir PATH      Where to output the generated project dir into
  --config-file PATH         User configuration file
  --default-config           Do not load a config file. Use the defaults
                             instead
  --debug-file PATH          File to be used as a stream for DEBUG logging
  -h, --help                 Show this message and exit.
```