### PR TITLE
load custom extensions in pre-hook

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -220,11 +220,18 @@ def ensure_dir_is_templated(dirname):
         raise NonTemplatedInputDirException
 
 
-def _run_hook_from_repo_dir(repo_dir, hook_name, project_dir, context):
-    """Run hook from repo directory, clean project directory if hook fails."""
+def _run_hook_from_repo_dir(repo_dir, hook_name, project_dir, context, env):
+    """Run hook from repo directory, clean project directory if hook fails.
+
+    :param repo_dir: Project template input directory.
+    :param hook_name: The hook to execute.
+    :param project_dir: The directory to execute the script from.
+    :param context: Cookiecutter project context.
+    :param env: Jinja2 template execution environment.
+    """
     with work_in(repo_dir):
         try:
-            run_hook(hook_name, project_dir, context)
+            run_hook(hook_name, project_dir, context, env)
         except FailedHookException:
             rmtree(project_dir)
             logger.error(
@@ -276,7 +283,13 @@ def generate_files(repo_dir, context=None, output_dir='.',
     project_dir = os.path.abspath(project_dir)
     logger.debug('Project directory is {}'.format(project_dir))
 
-    _run_hook_from_repo_dir(repo_dir, 'pre_gen_project', project_dir, context)
+    _run_hook_from_repo_dir(
+        repo_dir,
+        'pre_gen_project',
+        project_dir,
+        context,
+        env
+    )
 
     with work_in(template_dir):
         env.loader = FileSystemLoader('.')
@@ -346,6 +359,12 @@ def generate_files(repo_dir, context=None, output_dir='.',
                     msg = "Unable to create file '{}'".format(infile)
                     raise UndefinedVariableInTemplate(msg, err, context)
 
-    _run_hook_from_repo_dir(repo_dir, 'post_gen_project', project_dir, context)
+    _run_hook_from_repo_dir(
+        repo_dir,
+        'post_gen_project',
+        project_dir,
+        context,
+        env
+    )
 
     return project_dir

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -220,18 +220,17 @@ def ensure_dir_is_templated(dirname):
         raise NonTemplatedInputDirException
 
 
-def _run_hook_from_repo_dir(repo_dir, hook_name, project_dir, context, env):
+def _run_hook_from_repo_dir(repo_dir, hook_name, project_dir, context):
     """Run hook from repo directory, clean project directory if hook fails.
 
     :param repo_dir: Project template input directory.
     :param hook_name: The hook to execute.
     :param project_dir: The directory to execute the script from.
     :param context: Cookiecutter project context.
-    :param env: Jinja2 template execution environment.
     """
     with work_in(repo_dir):
         try:
-            run_hook(hook_name, project_dir, context, env)
+            run_hook(hook_name, project_dir, context)
         except FailedHookException:
             rmtree(project_dir)
             logger.error(
@@ -283,13 +282,7 @@ def generate_files(repo_dir, context=None, output_dir='.',
     project_dir = os.path.abspath(project_dir)
     logger.debug('Project directory is {}'.format(project_dir))
 
-    _run_hook_from_repo_dir(
-        repo_dir,
-        'pre_gen_project',
-        project_dir,
-        context,
-        env
-    )
+    _run_hook_from_repo_dir(repo_dir, 'pre_gen_project', project_dir, context)
 
     with work_in(template_dir):
         env.loader = FileSystemLoader('.')
@@ -359,12 +352,6 @@ def generate_files(repo_dir, context=None, output_dir='.',
                     msg = "Unable to create file '{}'".format(infile)
                     raise UndefinedVariableInTemplate(msg, err, context)
 
-    _run_hook_from_repo_dir(
-        repo_dir,
-        'post_gen_project',
-        project_dir,
-        context,
-        env
-    )
+    _run_hook_from_repo_dir(repo_dir, 'post_gen_project', project_dir, context)
 
     return project_dir

--- a/tests/test-extensions/custom-extension-post/hooks/post_gen_project.py
+++ b/tests/test-extensions/custom-extension-post/hooks/post_gen_project.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
 
-print({% hello cookiecutter.name %})
+print('{% hello cookiecutter.name %}')

--- a/tests/test-extensions/custom-extension-pre/hooks/pre_gen_project.py
+++ b/tests/test-extensions/custom-extension-pre/hooks/pre_gen_project.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
 
-print({% hello cookiecutter.name %})
+print('{% hello cookiecutter.name %}')

--- a/tests/test_custom_extensions_in_hooks.py
+++ b/tests/test_custom_extensions_in_hooks.py
@@ -32,10 +32,6 @@ def modify_syspath(monkeypatch):
     )
 
 
-@pytest.mark.xfail(
-    reason='issue #850',
-    strict=True,
-)
 def test_hook_with_extension(template, output_dir):
     project_dir = main.cookiecutter(
         template,

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -14,7 +14,6 @@ import sys
 import textwrap
 
 from cookiecutter import hooks, utils, exceptions
-from cookiecutter.environment import StrictEnvironment
 
 
 def make_test_repo(name):
@@ -102,7 +101,6 @@ class TestExternalHooks(object):
 
     repo_path = os.path.abspath('tests/test-hooks/')
     hooks_path = os.path.abspath('tests/test-hooks/hooks')
-    env = StrictEnvironment()
 
     def setup_method(self, method):
         self.post_hook = make_test_repo(self.repo_path)
@@ -165,8 +163,7 @@ class TestExternalHooks(object):
                 'cookiecutter': {
                     'file': 'context_post.txt'
                 }
-            },
-            self.env)
+            })
         assert os.path.isfile('tests/context_post.txt')
         assert 'tests' not in os.getcwd()
 
@@ -176,10 +173,10 @@ class TestExternalHooks(object):
         """
         tests_dir = os.path.join(self.repo_path, 'input{{hooks}}')
         with utils.work_in(self.repo_path):
-            hooks.run_hook('pre_gen_project', tests_dir, {}, self.env)
+            hooks.run_hook('pre_gen_project', tests_dir, {})
             assert os.path.isfile(os.path.join(tests_dir, 'python_pre.txt'))
 
-            hooks.run_hook('post_gen_project', tests_dir, {}, self.env)
+            hooks.run_hook('post_gen_project', tests_dir, {})
             assert os.path.isfile(os.path.join(tests_dir, 'shell_post.txt'))
 
     def test_run_failing_hook(self):
@@ -192,7 +189,7 @@ class TestExternalHooks(object):
 
         with utils.work_in(self.repo_path):
             with pytest.raises(exceptions.FailedHookException) as excinfo:
-                hooks.run_hook('pre_gen_project', tests_dir, {}, self.env)
+                hooks.run_hook('pre_gen_project', tests_dir, {})
             assert 'Hook script failed' in str(excinfo.value)
 
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -14,6 +14,7 @@ import sys
 import textwrap
 
 from cookiecutter import hooks, utils, exceptions
+from cookiecutter.environment import StrictEnvironment
 
 
 def make_test_repo(name):
@@ -101,6 +102,7 @@ class TestExternalHooks(object):
 
     repo_path = os.path.abspath('tests/test-hooks/')
     hooks_path = os.path.abspath('tests/test-hooks/hooks')
+    env = StrictEnvironment()
 
     def setup_method(self, method):
         self.post_hook = make_test_repo(self.repo_path)
@@ -163,7 +165,8 @@ class TestExternalHooks(object):
                 'cookiecutter': {
                     'file': 'context_post.txt'
                 }
-            })
+            },
+            self.env)
         assert os.path.isfile('tests/context_post.txt')
         assert 'tests' not in os.getcwd()
 
@@ -173,10 +176,10 @@ class TestExternalHooks(object):
         """
         tests_dir = os.path.join(self.repo_path, 'input{{hooks}}')
         with utils.work_in(self.repo_path):
-            hooks.run_hook('pre_gen_project', tests_dir, {})
+            hooks.run_hook('pre_gen_project', tests_dir, {}, self.env)
             assert os.path.isfile(os.path.join(tests_dir, 'python_pre.txt'))
 
-            hooks.run_hook('post_gen_project', tests_dir, {})
+            hooks.run_hook('post_gen_project', tests_dir, {}, self.env)
             assert os.path.isfile(os.path.join(tests_dir, 'shell_post.txt'))
 
     def test_run_failing_hook(self):
@@ -189,7 +192,7 @@ class TestExternalHooks(object):
 
         with utils.work_in(self.repo_path):
             with pytest.raises(exceptions.FailedHookException) as excinfo:
-                hooks.run_hook('pre_gen_project', tests_dir, {})
+                hooks.run_hook('pre_gen_project', tests_dir, {}, self.env)
             assert 'Hook script failed' in str(excinfo.value)
 
 


### PR DESCRIPTION
Fixes #850 

StrictEnvironment is used instead of Template when processing the pre-hook. I changed the hooks for the tests because strings weren't getting returned.