### PR TITLE
Reproducible build with default config

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -14,7 +14,6 @@ import json
 import click
 
 from cookiecutter import __version__
-from cookiecutter.config import USER_CONFIG_PATH
 from cookiecutter.log import configure_logger
 from cookiecutter.main import cookiecutter
 from cookiecutter.exceptions import (
@@ -80,7 +79,7 @@ def validate_extra_context(ctx, param, value):
     help=u'Where to output the generated project dir into'
 )
 @click.option(
-    u'--config-file', type=click.Path(), default=USER_CONFIG_PATH,
+    u'--config-file', type=click.Path(), default=None,
     help=u'User configuration file'
 )
 @click.option(
@@ -109,15 +108,14 @@ def main(
     )
 
     try:
-        user_config = None if default_config else config_file
-
         cookiecutter(
             template, checkout, no_input,
             extra_context=extra_context,
             replay=replay,
             overwrite_if_exists=overwrite_if_exists,
             output_dir=output_dir,
-            config_file=user_config
+            config_file=config_file,
+            default_config=default_config,
         )
     except (OutputDirExistsException,
             InvalidModeException,

--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -87,7 +87,7 @@ def get_user_config(config_file=None, default_config=False):
     raise an error if the specified path is not valid.
 
     If the environment variable is not set, try the default config file path
-    before falling back to the default config values. 
+    before falling back to the default config values.
     """
     # Do NOT load a config. Return defaults instead.
     if default_config:

--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -74,9 +74,20 @@ def get_config(config_path):
 
 
 def get_user_config(config_file=None, default_config=False):
-    """Retrieve the config from a file or return the defaults if None is
-    passed. If an environment variable `COOKIECUTTER_CONFIG` is set up, try
-    to load its value. Otherwise fall back to a default file or config.
+    """Return the user config as a dict.
+
+    If ``default_config`` is True, ignore ``config_file and return default
+    values for the config parameters.
+
+    If a path to a ``config_file`` is given, that is different from the default
+    location, load the user config from that.
+
+    Otherwise look up the config file path in the ``COOKIECUTTER_CONFIG``
+    environment variable. If set, load the config from this path. This will
+    raise an error if the specified path is not valid.
+
+    If the environment variable is not set, try the default config file path
+    before falling back to the default config values. 
     """
     # Do NOT load a config. Return defaults instead.
     if default_config:

--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -73,13 +73,13 @@ def get_config(config_path):
     return config_dict
 
 
-def get_user_config(config_file=USER_CONFIG_PATH):
+def get_user_config(config_file=None, default_config=False):
     """Retrieve the config from a file or return the defaults if None is
     passed. If an environment variable `COOKIECUTTER_CONFIG` is set up, try
     to load its value. Otherwise fall back to a default file or config.
     """
     # Do NOT load a config. Return defaults instead.
-    if config_file is None:
+    if default_config:
         return copy.copy(DEFAULT_CONFIG)
 
     # Load the given config file

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -14,7 +14,7 @@ from __future__ import unicode_literals
 import logging
 import os
 
-from .config import get_user_config, USER_CONFIG_PATH
+from .config import get_user_config
 from .generate import generate_context, generate_files
 from .exceptions import InvalidModeException
 from .prompt import prompt_for_config
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 def cookiecutter(
         template, checkout=None, no_input=False, extra_context=None,
         replay=False, overwrite_if_exists=False, output_dir='.',
-        config_file=USER_CONFIG_PATH):
+        config_file=None, default_config=False):
     """
     API equivalent to using Cookiecutter at the command line.
 
@@ -41,6 +41,7 @@ def cookiecutter(
         if it exists
     :param output_dir: Where to output the generated project dir into.
     :param config_file: User configuration file path.
+    :param default_config: Use default values rather than a config file.
     """
     if replay and ((no_input is not False) or (extra_context is not None)):
         err_msg = (
@@ -49,9 +50,10 @@ def cookiecutter(
         )
         raise InvalidModeException(err_msg)
 
-    # Get user config from ~/.cookiecutterrc or equivalent
-    # If no config file, sensible defaults from config.DEFAULT_CONFIG are used
-    config_dict = get_user_config(config_file=config_file)
+    config_dict = get_user_config(
+        config_file=config_file,
+        default_config=default_config,
+    )
 
     repo_dir = determine_repo_dir(
         template=template,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ import pytest
 
 from cookiecutter.__main__ import main
 from cookiecutter.main import cookiecutter
-from cookiecutter import utils, config
+from cookiecutter import utils
 
 
 @pytest.fixture(scope='session')
@@ -94,8 +94,9 @@ def test_cli_replay(mocker, cli_runner):
         replay=True,
         overwrite_if_exists=False,
         output_dir='.',
-        config_file=config.USER_CONFIG_PATH,
-        extra_context=None
+        config_file=None,
+        default_config=False,
+        extra_context=None,
     )
 
 
@@ -125,8 +126,9 @@ def test_cli_exit_on_noinput_and_replay(mocker, cli_runner):
         replay=True,
         overwrite_if_exists=False,
         output_dir='.',
-        config_file=config.USER_CONFIG_PATH,
-        extra_context=None
+        config_file=None,
+        default_config=False,
+        extra_context=None,
     )
 
 
@@ -155,8 +157,9 @@ def test_run_cookiecutter_on_overwrite_if_exists_and_replay(
         replay=True,
         overwrite_if_exists=True,
         output_dir='.',
-        config_file=config.USER_CONFIG_PATH,
-        extra_context=None
+        config_file=None,
+        default_config=False,
+        extra_context=None,
     )
 
 
@@ -213,8 +216,9 @@ def test_cli_output_dir(mocker, cli_runner, output_dir_flag, output_dir):
         replay=False,
         overwrite_if_exists=False,
         output_dir=output_dir,
-        config_file=config.USER_CONFIG_PATH,
-        extra_context=None
+        config_file=None,
+        default_config=False,
+        extra_context=None,
     )
 
 
@@ -251,7 +255,8 @@ def test_user_config(mocker, cli_runner, user_config_path):
         overwrite_if_exists=False,
         output_dir='.',
         config_file=user_config_path,
-        extra_context=None
+        default_config=False,
+        extra_context=None,
     )
 
 
@@ -276,7 +281,8 @@ def test_default_user_config_overwrite(mocker, cli_runner, user_config_path):
         replay=False,
         overwrite_if_exists=False,
         output_dir='.',
-        config_file=None,
+        config_file=user_config_path,
+        default_config=True,
         extra_context=None
     )
 
@@ -298,7 +304,8 @@ def test_default_user_config(mocker, cli_runner):
         overwrite_if_exists=False,
         output_dir='.',
         config_file=None,
-        extra_context=None
+        default_config=True,
+        extra_context=None,
     )
 
 

--- a/tests/test_get_user_config.py
+++ b/tests/test_get_user_config.py
@@ -132,7 +132,7 @@ def test_default_config_from_env_variable(
 def test_force_default_config(mocker):
     spy_get_config = mocker.spy(config, 'get_config')
 
-    user_config = config.get_user_config(None)
+    user_config = config.get_user_config(None, default_config=True)
 
     assert user_config == config.DEFAULT_CONFIG
     assert not spy_get_config.called


### PR DESCRIPTION
This is an alternative implementation for #800 to make kwargs deterministic.

I personally prefer a ``default_config=False`` flag over ``config_file=object()`` 🙊 

Please let me know your thoughts, @lamby. I should also mention that you will get credit for your contribution to cookiecutter regardless of whether we decide to use this PR instead of #800!