### PR TITLE
Allow Jinja extensions to be defined/bundled in the template repository

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -13,6 +13,7 @@ library rather than a script.
 from __future__ import unicode_literals
 import logging
 import os
+import sys
 
 from .config import get_user_config
 from .generate import generate_context, generate_files
@@ -62,6 +63,7 @@ def cookiecutter(
         checkout=checkout,
         no_input=no_input,
     )
+    sys.path.insert(0, repo_dir)
 
     template_name = os.path.basename(os.path.abspath(repo_dir))
 


### PR DESCRIPTION
This commit permits users to define custom Jinja extensions to be used in the `cookiecutter.json` file.

For example, with something like this in `template/helpers.py`: 
```python
from jinja2.ext import Extension


def get_app_slug(app_name):
    return app_name.lower()


class HelpersExtension(Extension):

    def __init__(self, environment):
        super(Extension, self).__init__()
        environment.filters["get_app_slug"] = get_app_slug

__all__ = ["HelpersExtension"]
```

It allows to use that Jinja filter directly:
```json
{
    "app_name": "ExampleProject",
    "app_slug": "{{cookiecutter.app_name|get_app_slug}}",
    "_extensions": ["helpers.HelpersExtension"]
}
``` 

This is really just a dumb example, but I'm pretty confident that it could be a powerful feature.

I'm kinda new to Cookiecutter, so please point me to the right direction if there's already another way to achieve something like this that I'm not aware of.