### PR TITLE
Remove beat-generator from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -504,10 +504,8 @@ Elm
 Golang
 ~~~~~~
 
-* `beat-generator`_: A template to create your own beat to ship data to Elasticsearch.
 * `cookiecutter-golang`_: A template to create new go based projects following best practices.
 
-.. _`beat-generator`: https://github.com/elastic/beat-generator
 .. _`cookiecutter-golang`: https://github.com/lacion/cookiecutter-golang 
 
 Java


### PR DESCRIPTION
For our newest version of the beat generator we use an in house built python script and not cookiecutter anymore.