### PR TITLE
Handle subprocess output.

### DIFF
--- a/cookiecutter/vcs.py
+++ b/cookiecutter/vcs.py
@@ -129,12 +129,13 @@ def clone(repo_url, checkout=None, clone_to_dir='.', no_input=False):
                 stderr=subprocess.STDOUT,
             )
     except subprocess.CalledProcessError as clone_error:
-        if 'not found' in clone_error.output.lower():
+        output = clone_error.output.decode()
+        if 'not found' in output.lower():
             raise RepositoryNotFound(
                 'The repository {} could not be found, '
                 'have you made a typo?'.format(repo_url)
             )
-        if any(error in clone_error.output for error in BRANCH_ERRORS):
+        if any(error in output for error in BRANCH_ERRORS):
             raise RepositoryCloneFailed(
                 'The {} branch of repository {} could not found, '
                 'have you made a typo?'.format(checkout, repo_url)

--- a/cookiecutter/vcs.py
+++ b/cookiecutter/vcs.py
@@ -129,7 +129,7 @@ def clone(repo_url, checkout=None, clone_to_dir='.', no_input=False):
                 stderr=subprocess.STDOUT,
             )
     except subprocess.CalledProcessError as clone_error:
-        output = clone_error.output.decode()
+        output = clone_error.output.decode('utf-8')
         if 'not found' in output.lower():
             raise RepositoryNotFound(
                 'The repository {} could not be found, '

--- a/tests/vcs/test_clone.py
+++ b/tests/vcs/test_clone.py
@@ -139,8 +139,8 @@ def test_clone_should_invoke_vcs_command(
 
 
 @pytest.mark.parametrize('error_message', [
-    "fatal: repository 'https://github.com/hackebro/cookiedozer' not found",
-    'hg: abort: HTTP Error 404: Not Found',
+    b"fatal: repository 'https://github.com/hackebro/cookiedozer' not found",
+    b'hg: abort: HTTP Error 404: Not Found',
 ])
 def test_clone_handles_repo_typo(mocker, clone_dir, error_message):
     """In `clone()`, repository not found errors should raise an
@@ -171,8 +171,8 @@ def test_clone_handles_repo_typo(mocker, clone_dir, error_message):
 
 
 @pytest.mark.parametrize('error_message', [
-    "error: pathspec 'unknown_branch' did not match any file(s) known to git.",
-    "hg: abort: unknown revision 'unknown_branch'!",
+    b"error: pathspec 'unknown_branch' did not match any file(s) known to git",
+    b"hg: abort: unknown revision 'unknown_branch'!",
 ])
 def test_clone_handles_branch_typo(mocker, clone_dir, error_message):
     """In `clone()`, branch not found errors should raise an
@@ -207,7 +207,7 @@ def test_clone_unknown_subprocess_error(mocker, clone_dir):
         'cookiecutter.vcs.subprocess.check_output',
         autospec=True,
         side_effect=[subprocess.CalledProcessError(
-            -1, 'cmd', output='Something went wrong'
+            -1, 'cmd', output=b'Something went wrong'
         )]
     )
 

--- a/tests/vcs/test_clone.py
+++ b/tests/vcs/test_clone.py
@@ -139,8 +139,11 @@ def test_clone_should_invoke_vcs_command(
 
 
 @pytest.mark.parametrize('error_message', [
-    b"fatal: repository 'https://github.com/hackebro/cookiedozer' not found",
-    b'hg: abort: HTTP Error 404: Not Found',
+    (
+        "fatal: repository 'https://github.com/hackebro/cookiedozer' "
+        "not found"
+    ).encode('utf-8'),
+    'hg: abort: HTTP Error 404: Not Found'.encode('utf-8'),
 ])
 def test_clone_handles_repo_typo(mocker, clone_dir, error_message):
     """In `clone()`, repository not found errors should raise an
@@ -171,8 +174,11 @@ def test_clone_handles_repo_typo(mocker, clone_dir, error_message):
 
 
 @pytest.mark.parametrize('error_message', [
-    b"error: pathspec 'unknown_branch' did not match any file(s) known to git",
-    b"hg: abort: unknown revision 'unknown_branch'!",
+    (
+        "error: pathspec 'unknown_branch' did not match any file(s) known "
+        "to git"
+    ).encode('utf-8'),
+    "hg: abort: unknown revision 'unknown_branch'!".encode('utf-8'),
 ])
 def test_clone_handles_branch_typo(mocker, clone_dir, error_message):
     """In `clone()`, branch not found errors should raise an
@@ -207,7 +213,7 @@ def test_clone_unknown_subprocess_error(mocker, clone_dir):
         'cookiecutter.vcs.subprocess.check_output',
         autospec=True,
         side_effect=[subprocess.CalledProcessError(
-            -1, 'cmd', output=b'Something went wrong'
+            -1, 'cmd', output='Something went wrong'.encode('utf-8')
         )]
     )
 


### PR DESCRIPTION
Subprocess returns a bytestring, so comparisons with strings in python
3.x throw unexpected errors. This patch decodes bytestrings to strings
and updates tests to return realistic output.

Here's some sample output when the target repo isn't found:

```
(cookiecutter)jmcarp@Joshuas-MBP-3|~/code/cookiecutter on master!
± cookiecutter https://github.com/not/exists
Traceback (most recent call last):
  File "/Users/jmcarp/miniconda/envs/cookiecutter/lib/python3.6/site-packages/cookiecutter/vcs.py", line 123, in clone
    stderr=subprocess.STDOUT,
  File "/Users/jmcarp/miniconda/envs/cookiecutter/lib/python3.6/subprocess.py", line 336, in check_output
    **kwargs).stdout
  File "/Users/jmcarp/miniconda/envs/cookiecutter/lib/python3.6/subprocess.py", line 418, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['git', 'clone', 'https://github.com/not/exists']' returned non-zero exit status 128.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/jmcarp/miniconda/envs/cookiecutter/bin/cookiecutter", line 11, in <module>
    load_entry_point('cookiecutter==1.5.1', 'console_scripts', 'cookiecutter')()
  File "/Users/jmcarp/miniconda/envs/cookiecutter/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/jmcarp/miniconda/envs/cookiecutter/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/jmcarp/miniconda/envs/cookiecutter/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/jmcarp/miniconda/envs/cookiecutter/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/jmcarp/miniconda/envs/cookiecutter/lib/python3.6/site-packages/cookiecutter/cli.py", line 123, in main
    default_config=default_config,
  File "/Users/jmcarp/miniconda/envs/cookiecutter/lib/python3.6/site-packages/cookiecutter/main.py", line 63, in cookiecutter
    no_input=no_input,
  File "/Users/jmcarp/miniconda/envs/cookiecutter/lib/python3.6/site-packages/cookiecutter/repository.py", line 84, in determine_repo_dir
    no_input=no_input,
  File "/Users/jmcarp/miniconda/envs/cookiecutter/lib/python3.6/site-packages/cookiecutter/vcs.py", line 132, in clone
    if 'not found' in clone_error.output.lower():
TypeError: a bytes-like object is required, not 'str'
```