### PR TITLE
pyramid-cookiecutter-starter add Chameleon choice

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -437,7 +437,7 @@ Python-Pyramid
 ^^^^^^^^^^^^^^
 
 * `pyramid-cookiecutter-alchemy`_: A Cookiecutter (project template) for creating a Pyramid project using SQLite for persistent storage, SQLAlchemy for an ORM, URL dispatch for routing, and Jinja2 for templating.
-* `pyramid-cookiecutter-starter`_: A Cookiecutter (project template) for creating a Pyramid starter project using URL dispatch for routing and Jinja2 for templating.
+* `pyramid-cookiecutter-starter`_: A Cookiecutter (project template) for creating a Pyramid starter project using URL dispatch for routing and either Jinja2 or Chameleon for templating.
 * `pyramid-cookiecutter-zodb`_: A Cookiecutter (project template) for creating a Pyramid project using ZODB for persistent storage, traversal for routing, and Chameleon for templating.
 * `substanced-cookiecutter`_: A cookiecutter (project template) for creating a Substance D starter project. Substance D is built on top of Pyramid.
 


### PR DESCRIPTION
We've added an option to pyramid-cookiecutter-starter for the user to select Chameleon for templating language in addition to Jinja2