### PR TITLE
Don't dereference symlinks when using copytree

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -107,6 +107,7 @@ Contributors
 * Abdó Roig-Maranges (`@aroig`_)
 * Steve Piercy (`@stevepiercy`_)
 * Corey (`@coreysnyder04`_)
+* Peter Bittner (`@bittner`_)
 
 .. _`@cedk`: https://github.com/cedk
 .. _`@johtso`: https://github.com/johtso
@@ -202,3 +203,4 @@ Contributors
 .. _`@aroig`: https://github.com/aroig
 .. _`@stevepiercy`: https://github.com/stevepiercy
 .. _`@coreysnyder04`: https://github.com/coreysnyder04
+.. _`@bittner`: https://github.com/bittner

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -311,7 +311,7 @@ def generate_files(repo_dir, context=None, output_dir='.',
                     'Copying dir {} to {} without rendering'
                     ''.format(indir, outdir)
                 )
-                shutil.copytree(indir, outdir)
+                shutil.copytree(indir, outdir, symlinks=True)
 
             # We mutate ``dirs``, because we only want to go through these dirs
             # recursively


### PR DESCRIPTION
This change addresses issues with dereferencing symlinks. See https://github.com/audreyr/cookiecutter/issues/865#issuecomment-293891002 for details.