### PR TITLE
Fix the py.test documentation broken link

### DIFF
--- a/docs/contributor_testing.rst
+++ b/docs/contributor_testing.rst
@@ -44,4 +44,4 @@ Python 3.3 tests fail locally
 Try upgrading Tox to the latest version. I noticed that they were failing
 locally with Tox 1.5 but succeeding when I upgraded to Tox 1.7.1.
 
-.. _`pytest usage docs`: https://pytest.org/latest/usage.html#specifying-tests-selecting-tests
+.. _`pytest usage docs`: https://docs.pytest.org/en/latest/usage.html#specifying-tests-selecting-tests


### PR DESCRIPTION
This pull request is for an update of a broken link to Py.test documentation referenced in Issue #939
Cheers