### PR TITLE
Add test_requirements.txt (fix #377)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,6 @@ ignore = E731
 [bdist_wheel]
 universal = 1
 
+[tool:pytest]
+testpaths = tests
+addopts = --cov=cookiecutter

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,6 @@
+-e .
+pytest
+pytest-cov
+pytest-mock==1.1
+pytest-catchlog
+freezegun


### PR DESCRIPTION
Tox is great. Although, a lot of people are used to the simpler `pip install -r test_requirements.txt` and `pytest` workflow, including me.

Adding this `test_requirements.txt` file doesn't cost much and makes things easier for new developers and for rapid testing.

This PR is related to #377.