### PR TITLE
Add cookie-cookie to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -459,6 +459,10 @@ Meta-templates for generating Cookiecutter project templates.
 
 .. _`cookiecutter-template`: https://github.com/eviweb/cookiecutter-template
 
+* `cookie-cookie`_: A project template for... project templates...
+
+.. _`cookie-cookie`: https://github.com/tuxredux/cookie-cookie
+
 Ansible
 ~~~~~~~
 
@@ -471,9 +475,9 @@ Ansible
 Git
 ~~~
 
-* `cookiecutter-git`_: Git Cookiecutter. A git repository project template!
+* `cookiecutter-git`_: A git repository project template!
 
-.. _`cookiecutter-git`: https://github.com/webevllc/cookiecutter-git
+.. _`cookiecutter-git`: https://github.com/tuxredux/cookiecutter-git
 
 
 C


### PR DESCRIPTION
I created my own version of [cookiecutter-template](https://github.com/eviweb/cookiecutter-template) based on my [cookiecutter-git](https://github.com/tuxredux/cookiecutter-git) project for automatic remote repository creation! I also transferred **cookiecutter-git** from the `webevllc` namespace to `tuxredux`, so I went ahead and fixed the broken link in `README.rst`. Thanks in advance for your time!