### PR TITLE
Add cookiecutter-pypackage-rust-cross-platform-publish

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -354,6 +354,7 @@ Python
 * `cookiecutter-pyqt4`_: A prebuilt PyQt4 GUI template with a logging support, structure for tests and separation of ui and worker components.
 * `cookiecutter-xontrib`_: A template for building xontribs, a.k.a `xonsh`_ contributions
 * `cookiecutter-conda-python`_: A template for building Conda Python packages
+* `cookiecutter-pypackage-rust-cross-platform-publish`_: A template for a Python wheel containing a Rust binary module that supports releasing on Windows, OSX and Linux. 
 
 .. _`cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
 .. _`cookiecutter-pipproject`: https://github.com/wdm0006/cookiecutter-pipproject
@@ -397,7 +398,7 @@ Python
 .. _`cookiecutter-xontrib`: https://github.com/laerus/cookiecutter-xontrib
 .. _`xonsh`: https://github.com/xonsh/xonsh
 .. _`cookiecutter-conda-python`: https://github.com/conda/cookiecutter-conda-python
-
+.. _`cookiecutter-pypackage-rust-cross-platform-publish`: https://github.com/mckaymatt/cookiecutter-pypackage-rust-cross-platform-publish
 
 Python-Django
 ^^^^^^^^^^^^^


### PR DESCRIPTION
[This is a project ](https://github.com/mckaymatt/cookiecutter-pypackage-rust-cross-platform-publish)I've been working on for a few weeks now. It allows you to publish wheels to Pypi with Rust binary modules. 

An example of the output can be seen at https://github.com/mckaymatt/rust_pypi_example/releases or with `pip install rust_pypi_example`