### PR TITLE
Preserve existing output directory on failure

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -2,19 +2,20 @@
 
 """Functions for generating a project from a project template."""
 from __future__ import unicode_literals
-from collections import OrderedDict
+
 import fnmatch
 import io
 import json
 import logging
 import os
 import shutil
+from collections import OrderedDict
 
-from jinja2 import FileSystemLoader
-from cookiecutter.environment import StrictEnvironment
-from jinja2.exceptions import TemplateSyntaxError, UndefinedError
 from binaryornot.check import is_binary
+from jinja2 import FileSystemLoader
+from jinja2.exceptions import TemplateSyntaxError, UndefinedError
 
+from .environment import StrictEnvironment
 from .exceptions import (
     NonTemplatedInputDirException,
     ContextDecodingException,
@@ -23,8 +24,8 @@ from .exceptions import (
     UndefinedVariableInTemplate
 )
 from .find import find_template
-from .utils import make_sure_path_exists, work_in, rmtree
 from .hooks import run_hook
+from .utils import make_sure_path_exists, work_in, rmtree
 
 logger = logging.getLogger(__name__)
 

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -220,14 +220,16 @@ def ensure_dir_is_templated(dirname):
         raise NonTemplatedInputDirException
 
 
-def _run_hook_from_repo_dir(repo_dir, hook_name, project_dir, context, delete_project_on_failure):
+def _run_hook_from_repo_dir(repo_dir, hook_name, project_dir, context,
+                            delete_project_on_failure):
     """Run hook from repo directory, clean project directory if hook fails.
 
     :param repo_dir: Project template input directory.
     :param hook_name: The hook to execute.
     :param project_dir: The directory to execute the script from.
     :param context: Cookiecutter project context.
-    :param delete_project_on_failure: Delete the project directory on hook failure?
+    :param delete_project_on_failure: Delete the project directory on hook
+        failure?
     """
     with work_in(repo_dir):
         try:
@@ -287,7 +289,7 @@ def generate_files(repo_dir, context=None, output_dir='.',
     # if we created the output directory, then it's ok to remove it
     # if rendering fails
     delete_project_on_failure = output_directory_created
-    
+
     _run_hook_from_repo_dir(
         repo_dir,
         'pre_gen_project',

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -338,7 +338,8 @@ def generate_files(repo_dir, context=None, output_dir='.',
                         overwrite_if_exists
                     )
                 except UndefinedError as err:
-                    rmtree(project_dir)
+                    if delete_project_on_failure:
+                        rmtree(project_dir)
                     _dir = os.path.relpath(unrendered_dir, output_dir)
                     msg = "Unable to create directory '{}'".format(_dir)
                     raise UndefinedVariableInTemplate(msg, err, context)
@@ -359,7 +360,8 @@ def generate_files(repo_dir, context=None, output_dir='.',
                 try:
                     generate_file(project_dir, infile, context, env)
                 except UndefinedError as err:
-                    rmtree(project_dir)
+                    if delete_project_on_failure:
+                        rmtree(project_dir)
                     msg = "Unable to create file '{}'".format(infile)
                     raise UndefinedVariableInTemplate(msg, err, context)
 

--- a/tests/test_generate_files.py
+++ b/tests/test_generate_files.py
@@ -239,6 +239,26 @@ def test_raise_undefined_variable_file_name(tmpdir, undefined_context):
     assert not output_dir.join('testproject').exists()
 
 
+def test_raise_undefined_variable_file_name_existing_project(
+        tmpdir, undefined_context):
+    output_dir = tmpdir.mkdir('output')
+
+    output_dir.join('testproject').mkdir()
+
+    with pytest.raises(exceptions.UndefinedVariableInTemplate) as err:
+        generate.generate_files(
+            repo_dir='tests/undefined-variable/file-name/',
+            output_dir=str(output_dir),
+            context=undefined_context,
+            overwrite_if_exists=True
+        )
+    error = err.value
+    assert "Unable to create file '{{cookiecutter.foobar}}'" == error.message
+    assert error.context == undefined_context
+
+    assert output_dir.join('testproject').exists()
+
+
 def test_raise_undefined_variable_file_content(tmpdir, undefined_context):
     output_dir = tmpdir.mkdir('output')
 
@@ -273,6 +293,30 @@ def test_raise_undefined_variable_dir_name(tmpdir, undefined_context):
     assert error.context == undefined_context
 
     assert not output_dir.join('testproject').exists()
+
+
+def test_raise_undefined_variable_dir_name_existing_project(
+        tmpdir, undefined_context):
+    output_dir = tmpdir.mkdir('output')
+
+    output_dir.join('testproject').mkdir()
+
+    with pytest.raises(exceptions.UndefinedVariableInTemplate) as err:
+        generate.generate_files(
+            repo_dir='tests/undefined-variable/dir-name/',
+            output_dir=str(output_dir),
+            context=undefined_context,
+            overwrite_if_exists=True
+        )
+    error = err.value
+
+    directory = os.path.join('testproject', '{{cookiecutter.foobar}}')
+    msg = "Unable to create directory '{}'".format(directory)
+    assert msg == error.message
+
+    assert error.context == undefined_context
+
+    assert output_dir.join('testproject').exists()
 
 
 def test_raise_undefined_variable_project_dir(tmpdir):

--- a/tests/test_generate_hooks.py
+++ b/tests/test_generate_hooks.py
@@ -31,14 +31,16 @@ def remove_additional_folders(request):
     Remove some special folders which are created by the tests.
     """
     def fin_remove_additional_folders():
-        if os.path.exists('tests/test-pyhooks/inputpyhooks'):
-            utils.rmtree('tests/test-pyhooks/inputpyhooks')
-        if os.path.exists('inputpyhooks'):
-            utils.rmtree('inputpyhooks')
-        if os.path.exists('tests/test-shellhooks'):
-            utils.rmtree('tests/test-shellhooks')
-        if os.path.exists('tests/test-hooks'):
-            utils.rmtree('tests/test-hooks')
+        directories_to_delete = [
+            'tests/test-pyhooks/inputpyhooks',
+            'inputpyhooks',
+            'inputhooks',
+            'tests/test-shellhooks',
+            'tests/test-hooks',
+        ]
+        for directory in directories_to_delete:
+            if os.path.exists(directory):
+                utils.rmtree(directory)
     request.addfinalizer(fin_remove_additional_folders)
 
 

--- a/tests/test_generate_hooks.py
+++ b/tests/test_generate_hooks.py
@@ -37,6 +37,8 @@ def remove_additional_folders(request):
             utils.rmtree('inputpyhooks')
         if os.path.exists('tests/test-shellhooks'):
             utils.rmtree('tests/test-shellhooks')
+        if os.path.exists('tests/test-hooks'):
+            utils.rmtree('tests/test-hooks')
     request.addfinalizer(fin_remove_additional_folders)
 
 
@@ -113,6 +115,65 @@ def test_oserror_hooks(mocker):
             overwrite_if_exists=True
         )
     assert message in str(excinfo.value)
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
+def test_run_failing_hook_removes_output_directory():
+    repo_path = os.path.abspath('tests/test-hooks/')
+    hooks_path = os.path.abspath('tests/test-hooks/hooks')
+
+    hook_dir = os.path.join(repo_path, 'hooks')
+    template = os.path.join(repo_path, 'input{{cookiecutter.hooks}}')
+    os.mkdir(repo_path)
+    os.mkdir(hook_dir)
+    os.mkdir(template)
+
+    hook_path = os.path.join(hooks_path, 'pre_gen_project.py')
+
+    with open(hook_path, 'w') as f:
+        f.write("#!/usr/bin/env python\n")
+        f.write("import sys; sys.exit(1)\n")
+
+    with pytest.raises(FailedHookException) as excinfo:
+        generate.generate_files(
+            context={
+                'cookiecutter': {'hooks': 'hooks'}
+            },
+            repo_dir='tests/test-hooks/',
+            overwrite_if_exists=True
+        )
+        assert 'Hook script failed' in str(excinfo.value)
+    assert not os.path.exists('inputhooks')
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
+def test_run_failing_hook_preserves_existing_output_directory():
+    repo_path = os.path.abspath('tests/test-hooks/')
+    hooks_path = os.path.abspath('tests/test-hooks/hooks')
+
+    hook_dir = os.path.join(repo_path, 'hooks')
+    template = os.path.join(repo_path, 'input{{cookiecutter.hooks}}')
+    os.mkdir(repo_path)
+    os.mkdir(hook_dir)
+    os.mkdir(template)
+
+    hook_path = os.path.join(hooks_path, 'pre_gen_project.py')
+
+    with open(hook_path, 'w') as f:
+        f.write("#!/usr/bin/env python\n")
+        f.write("import sys; sys.exit(1)\n")
+
+    os.mkdir('inputhooks')
+    with pytest.raises(FailedHookException) as excinfo:
+        generate.generate_files(
+            context={
+                'cookiecutter': {'hooks': 'hooks'}
+            },
+            repo_dir='tests/test-hooks/',
+            overwrite_if_exists=True
+        )
+        assert 'Hook script failed' in str(excinfo.value)
+    assert os.path.exists('inputhooks')
 
 
 def make_test_repo(name):


### PR DESCRIPTION
If a generated output directory already exists, we don't delete it on project generation failure.

Supersedes #684.
Fixes #629. 