### PR TITLE
Fix typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -335,7 +335,7 @@ Python
 * `cookiecutter-kivy`_: A template for NUI applications built upon the kivy python-framework.
 * `cookiedozer`_: A template for Python Kivy apps ready to be deployed to android devices with Buildozer.
 * `cookiecutter-pylibrary`_: An intricate template designed to quickly get started with good testing and packaging (working configuration for Tox, Pytest, Travis-CI, Coveralls, AppVeyor, Sphinx docs, isort, bumpversion, packaging checks etc).
-* `cookiecutter-pyvanguard`_: A template for cutting edge Python development. `Invoke`_, pytest, bumpversion, and Python 2/3 compatability.
+* `cookiecutter-pyvanguard`_: A template for cutting edge Python development. `Invoke`_, pytest, bumpversion, and Python 2/3 compatibility.
 * `Python-iOS-template`_: A template to create a Python project that will run on iOS devices.
 * `Python-Android-template`_: A template to create a Python project that will run on Android devices.
 * `cookiecutter-tryton`_: A template to create base and external Tryton modules.
@@ -407,7 +407,7 @@ Python-Django
 * `cookiecutter-djangopackage`_: A template designed to create reusable third-party PyPI friendly Django apps. Documentation is written in tutorial format.
 * `cookiecutter-django-cms`_: A template for Django CMS with simple Bootstrap 3 template. It has a quick start and deploy documentation.
 * `cookiecutter-django-crud`_: A template to create a Django app with boilerplate CRUD around a model including a factory and tests.
-* `cookiecutter-django-lborgav`_: Another cookiecutter template for Django project with Booststrap 3 and FontAwesome 4
+* `cookiecutter-django-lborgav`_: Another cookiecutter template for Django project with Bootstrap 3 and FontAwesome 4
 * `cookiecutter-django-paas`_: Django template ready to use in PAAS platforms like Heroku, OpenShift, etc..
 * `cookiecutter-django-rest-framework`_: A template for creating reusable Django REST Framework packages.
 * `cookiecutter-django-aws-eb`_: Get up and running with Django on AWS Elastic Beanstalk.
@@ -640,7 +640,7 @@ HTML
 
 * `cookiecutter-complexity`_: A cookiecutter for a Complexity static site with Bootstrap 3.
 * `cookiecutter-reveal.js`_: A cookiecutter template for reveal.js presentations.
-* `cookiecutter-tumblr-theme`_: A cookiecutter for a Tumblr theme project with GruntJS as concatination tool.
+* `cookiecutter-tumblr-theme`_: A cookiecutter for a Tumblr theme project with GruntJS as concatenation tool.
 
 .. _`cookiecutter-complexity`: https://github.com/audreyr/cookiecutter-complexity
 .. _`cookiecutter-reveal.js`: https://github.com/keimlink/cookiecutter-reveal.js
@@ -677,7 +677,7 @@ Data Science
 Reproducible Science
 ~~~~~~~~~~~~~~~~~~~~
 
-* `cookiecutter-reproducible-science`_: A cookiecutter template to start a reproducible and transparent science project including data, models, analysis, and reports (i.e., your scientifc paper) with close resemblances to the philosophy of Cookiecutter `Data Science`_.
+* `cookiecutter-reproducible-science`_: A cookiecutter template to start a reproducible and transparent science project including data, models, analysis, and reports (i.e., your scientific paper) with close resemblances to the philosophy of Cookiecutter `Data Science`_.
 
 .. _`cookiecutter-reproducible-science`: https://github.com/mkrapp/cookiecutter-reproducible-science
 

--- a/cookiecutter/exceptions.py
+++ b/cookiecutter/exceptions.py
@@ -47,7 +47,7 @@ class ConfigDoesNotExistException(CookiecutterException):
 class InvalidConfiguration(CookiecutterException):
     """
     Raised if the global configuration file is not valid YAML or is
-    badly contructed.
+    badly constructed.
     """
 
 

--- a/docs/advanced/suppressing_prompts.rst
+++ b/docs/advanced/suppressing_prompts.rst
@@ -1,4 +1,4 @@
-.. _supressing-command-line-prompts:
+.. _suppressing-command-line-prompts:
 
 Suppressing Command-Line Prompts
 --------------------------------
@@ -19,7 +19,7 @@ Cookiecutter will pick a default value if used with `no_input`::
 In this case it will be using the default defined in `cookiecutter.json` or `.cookiecutterrc`.
 
 .. note::
-   values from `cookiecutter.json` will be overriden by values from  `.cookiecutterrc`
+   values from `cookiecutter.json` will be overridden by values from  `.cookiecutterrc`
 
 Advanced Example: Defaults + Extra Context
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -56,7 +56,7 @@ You may need to restart your command prompt session to load the environment vari
 Packaging tools
 ^^^^^^^^^^^^^^^
 
-``pip`` and ``setuptools`` now come with Python 2 >=2.7.9 or Python 3 >=3.4. See the Python Packaging Authority's (PyPA) documention `Requirements for Installing Packages <https://packaging.python.org/en/latest/installing/#requirements-for-installing-packages>`_ for full details.
+``pip`` and ``setuptools`` now come with Python 2 >=2.7.9 or Python 3 >=3.4. See the Python Packaging Authority's (PyPA) documentation `Requirements for Installing Packages <https://packaging.python.org/en/latest/installing/#requirements-for-installing-packages>`_ for full details.
 
 
 Install cookiecutter

--- a/tests/replay/test_dump.py
+++ b/tests/replay/test_dump.py
@@ -35,7 +35,7 @@ def remove_replay_dump(request, replay_file):
 
 
 def test_type_error_if_no_template_name(replay_test_dir, context):
-    """Test that replay.dump raises if the tempate_name is not a valid str."""
+    """Test that replay.dump raises if the template_name is not a valid str."""
     with pytest.raises(TypeError):
         replay.dump(replay_test_dir, None, context)
 

--- a/tests/replay/test_load.py
+++ b/tests/replay/test_load.py
@@ -26,7 +26,7 @@ def replay_file(replay_test_dir, template_name):
 
 
 def test_type_error_if_no_template_name(replay_test_dir):
-    """Test that replay.load raises if the tempate_name is not a valid str."""
+    """Test that replay.load raises if the template_name is not a valid str."""
     with pytest.raises(TypeError):
         replay.load(replay_test_dir, None)
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -34,7 +34,7 @@ def test_convert_to_str(mocker, raw_var, rendered_var):
     result = prompt.render_variable(env, raw_var, context)
     assert result == rendered_var
 
-    # Make sure that non None non str variables are conerted beforehand
+    # Make sure that non None non str variables are converted beforehand
     if raw_var is not None:
         if not isinstance(raw_var, basestring):
             raw_var = str(raw_var)

--- a/tests/test_read_user_dict.py
+++ b/tests/test_read_user_dict.py
@@ -90,7 +90,7 @@ def test_should_raise_type_error(mocker):
 
 def test_should_call_prompt_with_process_json(mocker):
     """Test to make sure that process_jon is actually being used
-    to generate a processer for the user input."""
+    to generate a processor for the user input."""
 
     mock_prompt = mocker.patch(
         'cookiecutter.prompt.click.prompt',


### PR DESCRIPTION
  * `contructed    -> constructed`
  * `supressing    -> suppressing`
  * `overriden     -> overridden`
  * `documention   -> documentation`
  * `tempate_name  -> template_name`
  * `conerted      -> converted`
  * `processer     -> processor`
  * `compatability -> compatibility`
  * `Booststrap    -> Bootstrap`
  * `concatination -> concatenation`
  * `scientifc     -> scientific`
