### PR TITLE
add xdg & basic AppData support; fix existing tests

### DIFF
--- a/tests/test_get_config.py
+++ b/tests/test_get_config.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
 import pytest
 
 from cookiecutter import config
@@ -101,8 +100,10 @@ def test_get_config_with_defaults():
     A config file that overrides 1 of 3 defaults
     """
     conf = config.get_config('tests/test-config/valid-partial-config.yaml')
-    default_cookiecutters_dir = os.path.expanduser('~/.cookiecutters/')
-    default_replay_dir = os.path.expanduser('~/.cookiecutter_replay/')
+    # use the defaults directly rather than invoke config._find_user_data_dir;
+    # _find_user_data_dir should be an implementation detail
+    default_cookiecutters_dir = config.DEFAULT_CONFIG['cookiecutters_dir']
+    default_replay_dir = config.DEFAULT_CONFIG['replay_dir']
     expected_conf = {
         'cookiecutters_dir': default_cookiecutters_dir,
         'replay_dir': default_replay_dir,


### PR DESCRIPTION
Adds support for the XDG spec as per #104 and (sort of) #510. 

Users can specify a location for the config file and through the config file specify locations for cookiecutter related data, which I assume is new since the above mentioned issues were broached; however, it is somewhat roundabout and it would be preferable to explicitly support the "official" locations given by each platform for where an application is supposed to store its stuff.  Therefore, this patch implements the following behavior:

The user configuration file is searched for in the directories given by:

1.  `$COOKIECUTTER_CONFIG`: if set, always takes priority
2.  `~/.cookiecutterrc`: dotfiles in homedir take priority
2.  `$XDG_CONFIG_HOME/cookiecutter/config`: mostly Linux, I imagine, although I've heard of some OS X devs setting this envvar to aid Linux-native apps.
3.  `%APPDATA%\cookiecuttter\config`: Windows
4.  `~/.config/cookiecutter/config`:  this is for lazy-Linux; fairly often the env vars specified by XDG are not actually set, applications running on Linux just behave as though they were.
5.  `~/Library/Application\ Support/cookiecutter/config`: OS X specific; probably won't see much use

Similarly, the locations of `cookiecutters_dir` and `cookiecutter_replay` can now be overridden via the environment (`$COOKIECUTTERS_DIR` and `$COOKIECUTTER_REPLAY` respectively) and are searched for in the following list:

1.  The directory given by the appropriate environment var
2.  `$XDG_DATA_HOME/cookiecutter/<dir>`
3.  `%APPDATA%\<dir>`
4.  `~/.local/share/cookiecutter/<dir>` - see above note about lazy-Linux
5.  `~/Library/Application\ Support/cookiecutter/<dir>`
6.  The existing default locations of `~/.cookiecutters_dir/` and `.cookiecutter_replay`

In both cases the first location that exists is used.

**NOTE:** In order to preserve backwards compatibility and a seamless user experience, if the pre-existing default location for a file or dir is already populated, cookiecutter returns that path immediately instead of searching past item no. 1 on the above lists (i.e., this change _should_ only affect new installs and users who explicitly decide to move their config and/or data).

The existing test suite has been fixed to work with these changes.  Some work remains but I've decided to open this now for feedback, in case anyone has any. What remains is to:

1. Write tests that exercise the configuration / data directory finding functions _per platform_ - probably  by mocking out `sys.platform`
2. Update the documentation appropriately.

I could also whip up a quick CLI command to dump where cookiecutter thinks its config and data dirs are located if you think it would be helpful. 