### PR TITLE
pydocstyle for __init__.py

### DIFF
--- a/cookiecutter/__init__.py
+++ b/cookiecutter/__init__.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 
-"""
-cookiecutter
-------------
-
-Main package for Cookiecutter.
-"""
+"""Main package for Cookiecutter."""
 
 __version__ = '1.5.1'


### PR DESCRIPTION
This is for #742
I changed the format of the docstrings for cookiecutter/__init__.py to follow pep257 style