### PR TITLE
Drop support for EOL Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
     include:
       - python: 2.7
         env: TOX_ENV=py27
-      - python: 3.3
-        env: TOX_ENV=py33
       - python: 3.4
         env: TOX_ENV=py34
       - python: 3.5

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -153,8 +153,8 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.3, 3.4, 3.5, 3.6, and PyPy on
-   Appveyor and Travis CI.
+3. The pull request should work for Python 2.7, 3.4, 3.5, 3.6, and PyPy on
+   AppVeyor and Travis CI.
 4. Check https://travis-ci.org/audreyr/cookiecutter/pull_requests and 
    https://ci.appveyor.com/project/audreyr/cookiecutter/history to ensure the tests pass for all supported Python versions and platforms.
 
@@ -225,17 +225,6 @@ is::
 
 Will run py.test with the python2.7, python3.4 and pypy interpreters, for
 example.
-
-Troubleshooting for Contributors
---------------------------------
-
-Python 3.3 tests fail locally
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Try upgrading Tox to the latest version. I noticed that they were failing
-locally with Tox 1.5 but succeeding when I upgraded to Tox 1.7.1.
-
-.. _`pytest usage docs`: https://pytest.org/latest/usage.html#specifying-tests-selecting-tests
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,9 @@ Cookiecutter
 .. image:: https://img.shields.io/pypi/v/cookiecutter.svg
         :target: https://pypi.python.org/pypi/cookiecutter
 
+.. image:: https://img.shields.io/pypi/pyversions/cookiecutter.svg
+        :target: https://pypi.python.org/pypi/cookiecutter
+
 .. image:: https://travis-ci.org/audreyr/cookiecutter.svg?branch=master
         :target: https://travis-ci.org/audreyr/cookiecutter
 
@@ -48,7 +51,7 @@ Did someone say features?
 
 * Cross-platform: Windows, Mac, and Linux are officially supported.
 
-* Works with Python 2.7, 3.3, 3.4, 3.5, 3.6, and PyPy. *(But you don't have to
+* Works with Python 2.7, 3.4, 3.5, 3.6, and PyPy. *(But you don't have to
   know/write Python code to use Cookiecutter.)*
 
 * Project templates can be in any programming language or markup format:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,12 +9,6 @@ environment:
     - PYTHON: "C:\\Python27-x64"
       TOX_ENV: "py27"
 
-    - PYTHON: "C:\\Python33"
-      TOX_ENV: "py33"
-
-    - PYTHON: "C:\\Python33-x64"
-      TOX_ENV: "py33"
-
     - PYTHON: "C:\\Python34"
       TOX_ENV: "py34"
 

--- a/docs/contributor_testing.rst
+++ b/docs/contributor_testing.rst
@@ -34,14 +34,3 @@ is::
 
 Will run py.test with the python2.7, python3.4 and pypy interpreters, for
 example.
-
-Troubleshooting for Contributors
---------------------------------
-
-Python 3.3 tests fail locally
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Try upgrading Tox to the latest version. I noticed that they were failing
-locally with Tox 1.5 but succeeding when I upgraded to Tox 1.7.1.
-
-.. _`pytest usage docs`: https://docs.pytest.org/en/latest/usage.html#specifying-tests-selecting-tests

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         ]
     },
     include_package_data=True,
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=requirements,
     license='BSD',
     zip_safe=False,
@@ -71,7 +72,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
-pytest<3.3.0
+pytest
 pytest-cov
-pytest-mock==1.1
+pytest-mock
 pytest-catchlog
 freezegun

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, pypy, flake8
+envlist = py27, py34, py35, py36, pypy, flake8
 
 [testenv]
 passenv = LC_ALL, LANG, HOME


### PR DESCRIPTION
Fixes https://github.com/audreyr/cookiecutter/issues/1017.

Also add `python_requires` to setup.py to help pip, and PyPI Python version badges to READMEs.