### PR TITLE
Fixed broken link in `AUTHORS.rst`.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -117,7 +117,7 @@ Contributors
 * @meahow (`@meahow`_)
 * Andrea Grandi (`@andreagrandi`_)
 * Issa Jubril (`@jubrilissa`_)
-* Nytiennzo Madooray (`@Nytiennzo`_)
+* Nytiennzo Madooray (`@Nythiennzo`_)
 
 .. _`@cedk`: https://github.com/cedk
 .. _`@johtso`: https://github.com/johtso


### PR DESCRIPTION
Note:  The name appears to be spelt correctly; it's just the GitHub username that needs to be updated.