### PR TITLE
Use OrderedDict in generate_context()

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -5,6 +5,7 @@
 import os
 import sys
 import json
+import collections
 
 import click
 
@@ -42,7 +43,7 @@ def validate_extra_context(ctx, param, value):
 
     # Convert tuple -- e.g.: (u'program_name=foobar', u'startsecs=66')
     # to dict -- e.g.: {'program_name': 'foobar', 'startsecs': '66'}
-    return dict(s.split('=', 1) for s in value) or None
+    return collections.OrderedDict(s.split('=', 1) for s in value) or None
 
 
 @click.command(context_settings=dict(help_option_names=[u'-h', u'--help']))

--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -7,6 +7,7 @@ import copy
 import logging
 import os
 import io
+import collections
 
 import poyo
 
@@ -27,7 +28,7 @@ BUILTIN_ABBREVIATIONS = {
 DEFAULT_CONFIG = {
     'cookiecutters_dir': os.path.expanduser('~/.cookiecutters/'),
     'replay_dir': os.path.expanduser('~/.cookiecutter_replay/'),
-    'default_context': {},
+    'default_context': collections.OrderedDict([]),
     'abbreviations': BUILTIN_ABBREVIATIONS,
 }
 

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -256,7 +256,7 @@ def generate_files(repo_dir, context=None, output_dir='.',
     """
     template_dir = find_template(repo_dir)
     logger.debug('Generating project from {}...'.format(template_dir))
-    context = context or {}
+    context = context or OrderedDict([])
 
     unrendered_dir = os.path.split(template_dir)[1]
     ensure_dir_is_templated(unrendered_dir)

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -83,7 +83,7 @@ def generate_context(context_file='cookiecutter.json', default_context=None,
     :param default_context: Dictionary containing config to take into account.
     :param extra_context: Dictionary containing configuration overrides
     """
-    context = {}
+    context = OrderedDict([])
 
     try:
         with open(context_file) as file_handle:

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -193,7 +193,7 @@ def prompt_for_config(context, no_input=False):
 
     :param no_input: Prompt the user at command line for manual configuration?
     """
-    cookiecutter_dict = {}
+    cookiecutter_dict = OrderedDict([])
     env = StrictEnvironment(context=context)
 
     # First pass: Handle simple and raw variables, plus choices.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -333,7 +333,7 @@ def test_echo_undefined_variable_error(tmpdir, cli_runner):
     error = "Unable to create file '{{cookiecutter.foobar}}'"
     assert error in result.output
 
-    message = "Error message: 'dict object' has no attribute 'foobar'"
+    message = "Error message: 'collections.OrderedDict object' has no attribute 'foobar'"
     assert message in result.output
 
     context = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -333,7 +333,10 @@ def test_echo_undefined_variable_error(tmpdir, cli_runner):
     error = "Unable to create file '{{cookiecutter.foobar}}'"
     assert error in result.output
 
-    message = "Error message: 'collections.OrderedDict object' has no attribute 'foobar'"
+    message = (
+        "Error message: 'collections.OrderedDict object' "
+        "has no attribute 'foobar'"
+    )
     assert message in result.output
 
     context = {


### PR DESCRIPTION
I'm having problems getting these [pytest-cookies tests](https://github.com/hackebrot/pytest-cookies/pull/22) to pass, see [CI build log](https://travis-ci.org/hackebrot/pytest-cookies/jobs/374734814#L574).

```python
# -*- coding: utf-8 -*-

import collections

def test_bake_project(cookies):
    result = cookies.bake(extra_context=collections.OrderedDict([
        ('repo_name', 'cookies'),
        ('short_description', '{{cookiecutter.repo_name}} is awesome'),
    ]))

    assert result.exit_code == 0
    assert result.exception is None
    assert result.project.basename == 'cookies'
    assert result.project.isdir()

    assert result.context == {
        'repo_name': 'cookies',
        'short_description': 'cookies is awesome',
    }

    assert str(result) == '<Result {}>'.format(result.project)
```

We do load ``cookiecutter.json`` into an ``OrderedDict``, but use that to update a regular Python dict in ``generate_context()``. So we can't rely on the order of items in the returned context.


