### PR TITLE
Improve docstrings to decrease 'pep257' errrors

### DIFF
--- a/cookiecutter/exceptions.py
+++ b/cookiecutter/exceptions.py
@@ -10,7 +10,9 @@ All exceptions used in the Cookiecutter code base are defined here.
 
 class CookiecutterException(Exception):
     """
-    Base exception class. All Cookiecutter-specific exceptions should subclass
+    Base exception class.
+
+    All Cookiecutter-specific exceptions should subclass
     this class.
     """
 
@@ -18,6 +20,7 @@ class CookiecutterException(Exception):
 class NonTemplatedInputDirException(CookiecutterException):
     """
     Raised when a project's input dir is not templated.
+
     The name of the input directory should always contain a string that is
     rendered to something else, so that input_dir != output_dir.
     """
@@ -25,6 +28,8 @@ class NonTemplatedInputDirException(CookiecutterException):
 
 class UnknownTemplateDirException(CookiecutterException):
     """
+    Cannot determine which directory is the project template.
+
     Raised when Cookiecutter cannot determine which directory is the project
     template, e.g. more than one dir appears to be a template dir.
     """
@@ -32,6 +37,8 @@ class UnknownTemplateDirException(CookiecutterException):
 
 class MissingProjectDir(CookiecutterException):
     """
+    Cannot find generated project directory.
+
     Raised during cleanup when remove_repo() can't find a generated project
     directory inside of a repo.
     """
@@ -39,6 +46,8 @@ class MissingProjectDir(CookiecutterException):
 
 class ConfigDoesNotExistException(CookiecutterException):
     """
+    Config file not found.
+
     Raised when get_config() is passed a path to a config file, but no file
     is found at that path.
     """
@@ -46,58 +55,57 @@ class ConfigDoesNotExistException(CookiecutterException):
 
 class InvalidConfiguration(CookiecutterException):
     """
+    Configuration is not valid.
+
     Raised if the global configuration file is not valid YAML or is
     badly constructed.
     """
 
 
 class UnknownRepoType(CookiecutterException):
-    """
-    Raised if a repo's type cannot be determined.
-    """
+    """Raised if a repo's type cannot be determined."""
 
 
 class VCSNotInstalled(CookiecutterException):
-    """
-    Raised if the version control system (git or hg) is not installed.
-    """
+    """Raised if the version control system (git or hg) is not installed."""
 
 
 class ContextDecodingException(CookiecutterException):
-    """
-    Raised when a project's JSON context file can not be decoded.
-    """
+    """Raised when a project's JSON context file can not be decoded."""
 
 
 class OutputDirExistsException(CookiecutterException):
-    """
-    Raised when the output directory of the project exists already.
-    """
+    """Raised when the output directory of the project exists already."""
 
 
 class InvalidModeException(CookiecutterException):
     """
+    Called with both `no_input==True` and `replay==True`.
+
     Raised when cookiecutter is called with both `no_input==True` and
     `replay==True` at the same time.
     """
 
 
 class FailedHookException(CookiecutterException):
-    """
-    Raised when a hook script fails
-    """
+    """Raised when a hook script fails."""
 
 
 class UndefinedVariableInTemplate(CookiecutterException):
-    """Raised when a template uses a variable which is not defined in the
+    """Variable is not defined in the context.
+
+    Raised when a template uses a variable which is not defined in the
     context.
     """
+
     def __init__(self, message, error, context):
+        """Initialize exception."""
         self.message = message
         self.error = error
         self.context = context
 
     def __str__(self):
+        """Stringify error."""
         return (
             "{self.message}. "
             "Error message: {self.error.message}. "
@@ -111,6 +119,8 @@ class UnknownExtension(CookiecutterException):
 
 class RepositoryNotFound(CookiecutterException):
     """
+    Repository doesn't exist.
+
     Raised when the specified cookiecutter repository doesn't exist.
     """
 
@@ -121,6 +131,8 @@ class RepositoryCloneFailed(CookiecutterException):
 
 class InvalidZipRepository(CookiecutterException):
     """
+    Not a valid Zip archive.
+
     Raised when the specified cookiecutter repository isn't a valid
     Zip archive.
     """

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -22,8 +22,9 @@ from .environment import StrictEnvironment
 
 
 def read_user_variable(var_name, default_value):
-    """Prompt the user for the given variable and return the entered value
-    or the given default.
+    """Prompt the user for the given variable.
+
+    Return the entered value or the given default.
 
     :param str var_name: Variable of the context to query the user
     :param default_value: Value that will be returned if no input happens
@@ -50,7 +51,7 @@ def read_user_yes_no(question, default_value):
 
 
 def read_repo_password(question):
-    """Prompt the user to enter a password
+    """Prompt the user to enter a password.
 
     :param str question: Question to the user
     """
@@ -137,7 +138,9 @@ def read_user_dict(var_name, default_value):
 
 
 def render_variable(env, raw, cookiecutter_dict):
-    """Inside the prompting taken from the cookiecutter.json file, this renders
+    """Render next variable.
+
+    Inside the prompting taken from the cookiecutter.json file, this renders
     the next variable. For example, if a project_name is "Peanut Butter
     Cookie", the repo_name could be be rendered with:
 
@@ -174,8 +177,9 @@ def render_variable(env, raw, cookiecutter_dict):
 
 
 def prompt_choice_for_config(cookiecutter_dict, env, key, options, no_input):
-    """Prompt the user which option to choose from the given. Each of the
-    possible choices is rendered beforehand.
+    """Prompt the user which option to choose from the given.
+
+    Each of the possible choices is rendered beforehand.
     """
     rendered_options = [
         render_variable(env, raw, cookiecutter_dict) for raw in options
@@ -188,8 +192,9 @@ def prompt_choice_for_config(cookiecutter_dict, env, key, options, no_input):
 
 def prompt_for_config(context, no_input=False):
     """
-    Prompts the user to enter new config, using context as a source for the
-    field names and sample values.
+    Prompt the user to enter new config.
+
+    Use context as a source for the field names and sample values.
 
     :param no_input: Prompt the user at command line for manual configuration?
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,6 @@ def clean_system(request):
       `~/.cookiecutter_replay.backup/`
 
     """
-
     # If ~/.cookiecutterrc is pre-existing, move it to a temp location
     user_config_path = os.path.expanduser('~/.cookiecutterrc')
     user_config_path_backup = os.path.expanduser(
@@ -151,13 +150,15 @@ def clean_system(request):
 
 @pytest.fixture(scope='session')
 def user_dir(tmpdir_factory):
-    """Fixture that simulates the user's home directory"""
+    """Fixture that simulates the user's home directory."""
     return tmpdir_factory.mktemp('user_dir')
 
 
 @pytest.fixture(scope='session')
 def user_config_data(user_dir):
-    """Fixture that creates 2 Cookiecutter user config dirs in the user's home
+    """Create 2 Cookiecutter user config dirs in the user's home directory.
+
+    Fixture that creates 2 Cookiecutter user config dirs in the user's home
     directory:
     * `cookiecutters_dir`
     * `cookiecutter_replay`
@@ -175,7 +176,9 @@ def user_config_data(user_dir):
 
 @pytest.fixture(scope='session')
 def user_config_file(user_dir, user_config_data):
-    """Fixture that creates a config file called `config` in the user's home
+    """Create a config file called `config`.
+
+    Fixture that creates a config file called `config` in the user's home
     directory, with YAML from `user_config_data`.
 
     :param user_dir: Simulated user's home directory


### PR DESCRIPTION
From running `pep257 .` the only errors left now are

For several files, missing docstrings:

        D100: Missing docstring in public module
        D101: Missing docstring in public class
        D102: Missing docstring in public method
        D103: Missing docstring
        D104: Missing docstring in public package
        D105: Missing docstring in magic method

On line 1 for several files, for the encoding string: `# -*- coding: utf-8 -*-`:

        D205: 1 blank line required between summary line and description (found 0)
        D400: First line should end with a period (not 't')

Fixes https://github.com/audreyr/cookiecutter/issues/742.