### PR TITLE
Update unit tests for Click 7.0

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -390,7 +390,7 @@ def test_cli_extra_context_invalid_format(cli_runner):
         'ExtraContextWithNoEqualsSoInvalid',
     )
     assert result.exit_code == 2
-    assert 'Error: Invalid value for "extra_context"' in result.output
+    assert 'Error: Invalid value for "[EXTRA_CONTEXT]..."' in result.output
     assert 'should contain items of the form key=value' in result.output
 
 

--- a/tests/test_cookiecutter_invocation.py
+++ b/tests/test_cookiecutter_invocation.py
@@ -21,7 +21,7 @@ def test_should_raise_error_without_template_arg(capfd):
         subprocess.check_call(['python', '-m', 'cookiecutter.cli'])
 
     _, err = capfd.readouterr()
-    exp_message = 'Error: Missing argument "template".'
+    exp_message = 'Error: Missing argument "TEMPLATE".'
     assert exp_message in err
 
 


### PR DESCRIPTION
Fixed two unit tests that fail with Click 7.0 (see #1109 for details).

Fixes #1109.

The tests now pass with Click 7.0, but will fail with older versions of Click due to small differences in usage error messages. Do the tests need to pass with all supported versions of Click (>=5.0) or is it sufficient to have them pass with the latest supported version of Click?