### PR TITLE
Unbreak tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -390,7 +390,7 @@ def test_cli_extra_context_invalid_format(cli_runner):
         'ExtraContextWithNoEqualsSoInvalid',
     )
     assert result.exit_code == 2
-    assert 'Error: Invalid value for "extra_context"' in result.output
+    assert 'Error: Invalid value for "[EXTRA_CONTEXT]..."' in result.output
     assert 'should contain items of the form key=value' in result.output
 
 

--- a/tests/test_cookiecutter_invocation.py
+++ b/tests/test_cookiecutter_invocation.py
@@ -21,7 +21,7 @@ def test_should_raise_error_without_template_arg(capfd):
         subprocess.check_call(['python', '-m', 'cookiecutter.cli'])
 
     _, err = capfd.readouterr()
-    exp_message = 'Error: Missing argument "template".'
+    exp_message = 'Error: Missing argument "TEMPLATE".'
     assert exp_message in err
 
 


### PR DESCRIPTION
While working on
- https://github.com/audreyr/cookiecutter/pull/1106
- https://github.com/audreyr/cookiecutter/pull/1107

I noticed that the tests are failing on unrelated issues. Created the PR here with vanilla `master` first and verified that the tests fail already there.

Seems that `click` v7.0 introduces some new error reporting. So I think either we change the tests like this or figure out a nice way to freeze the click dependency at `v6`.